### PR TITLE
[Real-time Table Replication X clusters][2/n] Create a Controller Job for historical segments ba…

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -23,7 +23,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>2.3</version>
+        <version>2.3.1</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Apache Pinot - AGENTS Guide
+
+This file provides quick, practical guidance for coding agents working in this
+repo. It is intentionally short and focused on day-to-day work.
+
+## Project overview
+- Apache Pinot is a real-time distributed OLAP datastore for low-latency
+  analytics over streaming and batch data.
+- Core runtime roles: broker (query routing), server (segment storage/execution),
+  controller (cluster metadata/management), minion (async tasks).
+
+## Repository layout (high level)
+- pinot-broker: broker query planning and scatter-gather.
+- pinot-controller: controller APIs, table/segment metadata, Helix management.
+- pinot-server: server query execution, segment loading, indexing.
+- pinot-minion: background tasks (segment conversion, purge, etc).
+- pinot-common / pinot-spi: shared utils, config, and SPI interfaces.
+- pinot-segment-local / pinot-segment-spi: segment generation, indexes, storage.
+- pinot-query-planner / pinot-query-runtime: multi-stage query (MSQ) engine.
+- pinot-connectors: external tooling to connect to Pinot
+- pinot-plugins: all pinot plugins.
+- pinot-tools: CLI and quickstart scripts.
+- pinot-integration-tests: end-to-end validation suites.
+- pinot-distribution: packaging artifacts.
+
+## pinot-plugins modules
+- pinot-input-format: input format plugin family.
+  - pinot-arrow: Apache Arrow input format support.
+  - pinot-avro: Avro input format support.
+  - pinot-avro-base: shared Avro utilities and base classes.
+  - pinot-clp-log: CLP log input format support.
+  - pinot-confluent-avro: Confluent Schema Registry Avro input support.
+  - pinot-confluent-json: Confluent Schema Registry JSON input support.
+  - pinot-confluent-protobuf: Confluent Schema Registry Protobuf input support.
+  - pinot-orc: ORC input format support.
+  - pinot-json: JSON input format support.
+  - pinot-parquet: Parquet input format support.
+  - pinot-csv: CSV input format support.
+  - pinot-thrift: Thrift input format support.
+  - pinot-protobuf: Protobuf input format support.
+- pinot-file-system: filesystem plugin family.
+  - pinot-adls: Azure Data Lake Storage (ADLS) filesystem support.
+  - pinot-hdfs: Hadoop HDFS filesystem support.
+  - pinot-gcs: Google Cloud Storage filesystem support.
+  - pinot-s3: Amazon S3 filesystem support.
+- pinot-batch-ingestion: batch ingestion plugin family.
+  - pinot-batch-ingestion-common: shared batch ingestion APIs and utilities.
+  - pinot-batch-ingestion-spark-base: shared Spark ingestion base classes.
+  - pinot-batch-ingestion-spark-2.4: Spark 2.4 ingestion implementation.
+  - pinot-batch-ingestion-spark-3: Spark 3 ingestion implementation.
+  - pinot-batch-ingestion-hadoop: Hadoop MapReduce ingestion implementation.
+  - pinot-batch-ingestion-standalone: standalone batch ingestion implementation.
+- pinot-stream-ingestion: stream ingestion plugin family.
+  - pinot-kafka-base: shared Kafka ingestion base classes.
+  - pinot-kafka-2.0: Kafka 2.x ingestion implementation.
+  - pinot-kafka-3.0: Kafka 3.x ingestion implementation.
+  - pinot-kinesis: AWS Kinesis ingestion implementation.
+  - pinot-pulsar: Apache Pulsar ingestion implementation.
+- pinot-minion-tasks: minion task plugin family.
+  - pinot-minion-builtin-tasks: built-in minion task implementations.
+- pinot-metrics: metrics reporter plugin family.
+  - pinot-dropwizard: Dropwizard Metrics reporter implementation.
+  - pinot-yammer: Yammer Metrics reporter implementation.
+  - pinot-compound-metrics: compound metrics implementation.
+- pinot-segment-writer: segment writer plugin family.
+  - pinot-segment-writer-file-based: file-based segment writer implementation.
+- pinot-segment-uploader: segment uploader plugin family.
+  - pinot-segment-uploader-default: default segment uploader implementation.
+- pinot-environment: environment provider plugin family.
+  - pinot-azure: Azure environment provider implementation.
+- pinot-timeseries-lang: time series language plugin family.
+  - pinot-timeseries-m3ql: M3QL language plugin implementation.
+- assembly-descriptor: Maven assembly descriptor for plugin packaging.
+
+## Build and test
+- Build JDK: Use JDK 11+ (CI runs 11/21); code targets Java 11.
+- Runtime JRE: Broker/server/controller/minion run on Java 11+.
+- Default build: `./mvnw clean install`
+- Faster dev build: `./mvnw verify -Ppinot-fastdev`
+- Full binary/shaded build:
+  `./mvnw clean install -DskipTests -Pbin-dist -Pbuild-shaded-jar`
+- Build a module with deps: `./mvnw -pl pinot-server -am test`
+- Single test example: `./mvnw -pl pinot-segment-local -Dtest=RangeIndexTest test`
+- Quickstart (after build): `build/bin/quick-start-batch.sh`
+
+## Integration tests
+- Single integration test example: `./mvnw -pl pinot-integration-tests -am -Dtest=OfflineClusterIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`
+
+## Coding conventions and hygiene
+- Add class-level Javadoc for new classes; describe behavior and thread-safety.
+- Use Javadoc comments with either `/** ... */` or `///` syntax (per JEP-467); code targets Java 11.
+- Keep license headers on all new source files.
+- Use `./mvnw license:format` to add headers to new files.
+- Preserve backward compatibility across mixed-version broker/server/controller.
+- Prefer targeted unit tests; use integration tests when behavior crosses roles.
+
+## Checkstyle config
+- Checkstyle rules and related config files live under `config/`.
+- Use the Maven wrapper (`./mvnw` on Unix-like systems or `mvnw.cmd` on Windows) to run `spotless:apply` to format code and `checkstyle:check` to validate style.
+- Run `./mvnw license:check` to validate license headers.
+
+## Change guidance
+- Query changes often touch broker planning and server execution; verify both.
+- Segment/index changes usually live under `pinot-segment-local` and
+  `pinot-segment-spi`.
+- Config or API changes should update relevant configs and docs where applicable.
+
+## Reference docs
+- `README.md` for build and quickstart details.
+- `CONTRIBUTING.md` for style, licensing, and contribution guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 # Apache Pinot - AGENTS Guide
 
 This file provides quick, practical guidance for coding agents working in this

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -342,6 +342,13 @@ public class PinotClientRequest {
           }
       });
 
+      if (isExplainMode(requestJson)) {
+        BrokerResponse explainResponse = _requestHandler.handleExplainTimeSeriesRequest(language, queryString,
+          queryParams);
+        asyncResponse.resume(explainResponse);
+        return;
+      }
+
       try (RequestScope requestContext = Tracing.getTracer().createRequestScope()) {
         TimeSeriesBlock timeSeriesBlock = executeTimeSeriesQuery(language, queryString, queryParams,
             requestContext, makeHttpIdentity(requestCtx), httpHeaders);
@@ -639,6 +646,10 @@ public class PinotClientRequest {
       HttpHeaders httpHeaders) throws QueryException {
     return _requestHandler.handleTimeSeriesRequest(language, queryString, queryParams, requestContext,
         requesterIdentity, httpHeaders);
+  }
+
+  private static boolean isExplainMode(JsonNode requestJson) {
+    return requestJson.has("mode") && "explain".equalsIgnoreCase(requestJson.get("mode").asText());
   }
 
   public static HttpRequesterIdentity makeHttpIdentity(org.glassfish.grizzly.http.server.Request context) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -309,9 +309,6 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _isStarting = true;
     Utils.logVersions();
 
-    LOGGER.info("Connecting spectator Helix manager");
-    initSpectatorHelixManager();
-
     LOGGER.info("Setting up broker request handler");
     // Set up metric registry and broker metrics
     _metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(_brokerConf.subset(Broker.METRICS_CONFIG_PREFIX));
@@ -328,6 +325,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         _brokerConf.getProperty(Broker.AdaptiveServerSelector.CONFIG_OF_TYPE,
             Broker.AdaptiveServerSelector.DEFAULT_TYPE), 1);
     BrokerMetrics.register(_brokerMetrics);
+
+    LOGGER.info("Connecting spectator Helix manager");
+    initSpectatorHelixManager();
+
     // Set up request handling classes
     _serverRoutingStatsManager = new ServerRoutingStatsManager(_brokerConf, _brokerMetrics);
     _serverRoutingStatsManager.init();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -415,6 +415,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
           new MultiStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _multiStageQueryThrottler, _failureDetector,
               _threadAccountant, multiClusterRoutingContext);
+      MultiStageBrokerRequestHandler finalHandler = multiStageBrokerRequestHandler;
+      _routingManager.setServerReenableCallback(
+          serverInstance -> finalHandler.getQueryDispatcher().resetClientConnectionBackoff(serverInstance));
     }
     TimeSeriesRequestHandler timeSeriesRequestHandler = null;
     if (StringUtils.isNotBlank(_brokerConf.getProperty(PinotTimeSeriesConfiguration.getEnabledLanguagesConfigKey()))) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
@@ -331,7 +331,6 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
         handlers.put(ChangeType.IDEAL_STATE, Collections.singletonList(routingManager));
         handlers.put(ChangeType.EXTERNAL_VIEW, Collections.singletonList(routingManager));
         handlers.put(ChangeType.INSTANCE_CONFIG, Collections.singletonList(routingManager));
-        handlers.put(ChangeType.RESOURCE_CONFIG, Collections.singletonList(routingManager));
 
         ClusterChangeMediator mediator = new ClusterChangeMediator(handlers, _brokerMetrics);
         mediator.start();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
@@ -22,8 +22,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.helix.HelixConstants.ChangeType;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -65,6 +67,9 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
   protected MultiClusterRoutingManager _multiClusterRoutingManager;
   protected MultiClusterRoutingContext _multiClusterRoutingContext;
   protected Map<String, ClusterChangeMediator> _remoteClusterChangeMediator;
+
+  // Tracks clusters that failed to connect (for adding warnings to query responses)
+  protected Set<String> _unavailableClusters;
 
   public MultiClusterHelixBrokerStarter() {
   }
@@ -121,6 +126,7 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
   }
 
   private void initRemoteClusterSpectatorHelixManagers() throws Exception {
+    _unavailableClusters = new HashSet<>();
     if (_remoteZkServers == null || _remoteZkServers.isEmpty()) {
       LOGGER.info("[multi-cluster] No remote ZK servers configured - skipping spectator Helix manager init");
       return;
@@ -141,6 +147,7 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
         LOGGER.info("[multi-cluster] Connected to remote cluster '{}' at ZK: {}", clusterName, zkServers);
       } catch (Exception e) {
         LOGGER.error("[multi-cluster] Failed to connect to cluster '{}' at ZK: {}", clusterName, zkServers, e);
+        _unavailableClusters.add(clusterName);
         _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MULTI_CLUSTER_BROKER_STARTUP_FAILURE, 1);
       }
     }
@@ -151,6 +158,10 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
     } else {
       LOGGER.info("[multi-cluster] Connected to {}/{} remote clusters: {}", _remoteSpectatorHelixManager.size(),
         _remoteZkServers.size(), _remoteSpectatorHelixManager.keySet());
+    }
+    if (!_unavailableClusters.isEmpty()) {
+      LOGGER.warn("[multi-cluster] The following clusters are unavailable and will generate warnings "
+          + "in query responses: {}", _unavailableClusters);
     }
   }
 
@@ -271,9 +282,11 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
     }
 
     _multiClusterRoutingContext = new MultiClusterRoutingContext(tableCacheMap, _routingManager,
-        _multiClusterRoutingManager);
-    LOGGER.info("[multi-cluster] Created federation provider with {}/{} clusters (1 primary + {} remote)",
-        tableCacheMap.size(), _remoteSpectatorHelixManager.size() + 1, tableCacheMap.size() - 1);
+        _multiClusterRoutingManager, _unavailableClusters);
+    LOGGER.info("[multi-cluster] Created federation provider with {}/{} clusters (1 primary + {} remote), "
+            + "{} unavailable",
+        tableCacheMap.size(), _remoteSpectatorHelixManager.size() + 1, tableCacheMap.size() - 1,
+        _unavailableClusters.size());
   }
 
   private void initRemoteClusterRouting() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -79,20 +79,40 @@ public class QueryLogger {
     _logBeforeProcessing = logBeforeProcessing;
   }
 
-  public void log(long requestId, String query) {
-    if (!_logBeforeProcessing || !checkRateLimiter(null)) {
-      return;
+  /**
+   * Logs the query received message before processing begins.
+   * This method checks the rate limiter and returns whether logging was allowed.
+   * The return value should be passed to logQueryCompleted.
+   *
+   * @param requestId the request ID
+   * @param query the SQL query
+   * @return true if the rate limiter allowed this query (not rate-limited), false if rate-limited
+   */
+  public boolean logQueryReceived(long requestId, String query) {
+    if (!checkRateLimiter()) {
+      return false;
     }
 
-    _logger.info("SQL query for request {}: {}", requestId, query);
+    if (_logBeforeProcessing) {
+      _logger.info("SQL query for request {}: {}", requestId, query);
+    }
 
     tryLogDropped();
+    return true;
   }
 
-  public void log(QueryLogParams params) {
+  /**
+   * Logs the query completion stats after processing completes.
+   *
+   * @param params the query log parameters
+   * @param wasLogged true if logQueryReceived returned true, false otherwise.
+   *                  When false, the completion log will only be emitted if force-log
+   *                  conditions are met (exceptions, slow queries).
+   */
+  public void logQueryCompleted(QueryLogParams params, boolean wasLogged) {
     _logger.debug("Broker Response: {}", params._response);
 
-    if (!checkRateLimiter(params)) {
+    if (!wasLogged && !shouldForceLog(params)) {
       return;
     }
 
@@ -110,8 +130,8 @@ public class QueryLogger {
     tryLogDropped();
   }
 
-  private boolean checkRateLimiter(@Nullable QueryLogParams params) {
-    boolean allowed = _logRateLimiter.tryAcquire() || shouldForceLog(params);
+  private boolean checkRateLimiter() {
+    boolean allowed = _logRateLimiter.tryAcquire();
     if (!allowed) {
       _numDroppedLogs.incrementAndGet();
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -150,18 +150,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     requestContext.setBrokerId(_brokerId);
     long requestId = _requestIdGenerator.get();
     requestContext.setRequestId(requestId);
-
-    if (httpHeaders != null && !_trackedHeaders.isEmpty()) {
-      MultivaluedMap<String, String> requestHeaders = httpHeaders.getRequestHeaders();
-      Map<String, List<String>> trackedHeadersMap = Maps.newHashMapWithExpectedSize(_trackedHeaders.size());
-      for (Map.Entry<String, List<String>> entry : requestHeaders.entrySet()) {
-        String key = entry.getKey().toLowerCase();
-        if (_trackedHeaders.contains(key)) {
-          trackedHeadersMap.put(key, entry.getValue());
-        }
-      }
-      requestContext.setRequestHttpHeaders(trackedHeadersMap);
-    }
+    setTrackedHeadersInRequestContext(requestContext, httpHeaders, _trackedHeaders);
 
     // First-stage access control to prevent unauthenticated requests from using up resources. Secondary table-level
     // check comes later.
@@ -359,6 +348,21 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     statistics.setExplainPlanNumEmptyFilterSegments(response.getExplainPlanNumEmptyFilterSegments());
     statistics.setExplainPlanNumMatchAllFilterSegments(response.getExplainPlanNumMatchAllFilterSegments());
     statistics.setTraceInfo(response.getTraceInfo());
+  }
+
+  protected static void setTrackedHeadersInRequestContext(RequestContext requestContext,
+      HttpHeaders httpHeaders, Set<String> trackedHeaders) {
+    if (httpHeaders != null && !trackedHeaders.isEmpty()) {
+      MultivaluedMap<String, String> requestHeaders = httpHeaders.getRequestHeaders();
+      Map<String, List<String>> trackedHeadersMap = Maps.newHashMapWithExpectedSize(trackedHeaders.size());
+      for (Map.Entry<String, List<String>> entry : requestHeaders.entrySet()) {
+        String key = entry.getKey().toLowerCase();
+        if (trackedHeaders.contains(key)) {
+          trackedHeadersMap.put(key, entry.getValue());
+        }
+      }
+      requestContext.setRequestHttpHeaders(trackedHeadersMap);
+    }
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -849,6 +849,15 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     for (QueryProcessingException errorMsg : errorMsgs) {
       brokerResponse.addException(errorMsg);
     }
+
+    // Add warnings for unavailable remote clusters in multi-cluster routing.
+    if (_multiClusterRoutingContext != null && QueryOptionsUtils.isMultiClusterRoutingEnabled(
+        pinotQuery.getQueryOptions(), false)) {
+      for (QueryProcessingException clusterException : _multiClusterRoutingContext.getUnavailableClusterExceptions()) {
+        brokerResponse.addException(clusterException);
+      }
+    }
+
     brokerResponse.setNumSegmentsPrunedByBroker(numPrunedSegmentsTotal);
     long executionEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_EXECUTION,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -71,6 +71,15 @@ public interface BrokerRequestHandler {
     throw new UnsupportedOperationException("Handler does not support Time Series requests");
   }
 
+  /**
+   * Handle an explain request for time-series queries.
+   * Returns a BrokerResponse containing the logical explain plan.
+   */
+  default BrokerResponse handleExplainTimeSeriesRequest(String lang, String rawQueryParamString,
+      Map<String, String> queryParams) {
+    throw new UnsupportedOperationException("Handler does not support Time Series explain requests");
+  }
+
   Map<Long, String> getRunningQueries();
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -136,6 +136,15 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
   }
 
   @Override
+  public BrokerResponse handleExplainTimeSeriesRequest(String lang, String rawQueryParamString,
+      Map<String, String> queryParams) {
+    if (_timeSeriesRequestHandler != null) {
+      return _timeSeriesRequestHandler.handleExplainTimeSeriesRequest(lang, rawQueryParamString, queryParams);
+    }
+    throw new QueryException(QueryErrorCode.INTERNAL, "Time series query engine not enabled.");
+  }
+
+  @Override
   public Map<Long, String> getRunningQueries() {
     // Both engines share the same request ID generator, so the query will have unique IDs across the two engines.
     Map<Long, String> queries = new HashMap<>(_singleStageBrokerRequestHandler.getRunningQueries());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -678,6 +678,15 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       }
       requestContext.setNumUnavailableSegments(numUnavailableSegments);
 
+      // Add warnings for unavailable remote clusters in multi-cluster routing
+      if (_multiClusterRoutingContext != null && QueryOptionsUtils.isMultiClusterRoutingEnabled(query.getOptions(),
+          false)) {
+        for (QueryProcessingException clusterException
+            : _multiClusterRoutingContext.getUnavailableClusterExceptions()) {
+          brokerResponse.addException(clusterException);
+        }
+      }
+
       fillOldBrokerResponseStats(brokerResponse, queryResults.getQueryStats(), dispatchableSubPlan);
       long totalTimeMs = System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis();
       _brokerMetrics.addTimedValue(BrokerTimer.MULTI_STAGE_QUERY_TOTAL_TIME_MS, totalTimeMs, TimeUnit.MILLISECONDS);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -855,4 +855,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         return false;
     }
   }
+
+  public QueryDispatcher getQueryDispatcher() {
+    return _queryDispatcher;
+  }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -406,7 +406,7 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
       RangeTimeSeriesRequest request = buildRangeTimeSeriesRequest(lang, rawQueryParamString, queryParams);
       TimeSeriesLogicalPlanResult planResult = _queryEnvironment.buildLogicalPlan(request);
       String plan = explainPlanTree(planResult.getPlanNode(), new StringBuilder(), 0).toString();
-      DataSchema schema = new DataSchema(new String[]{"SQL", "PLAN"},
+      DataSchema schema = new DataSchema(new String[]{"QUERY", "PLAN"},
           new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
       BrokerResponseNative response = BrokerResponseNative.empty();
       response.setResultTable(new ResultTable(schema, Collections.singletonList(new Object[]{request.getQuery(),

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerTest.java
@@ -1,0 +1,220 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.manager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.helix.AccessOption;
+import org.apache.helix.BaseDataAccessor;
+import org.apache.helix.HelixConstants.ChangeType;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class BrokerRoutingManagerTest {
+  private static final String SERVER_INSTANCE_ID = "Server_localhost_8000";
+  private static final String SERVER_HOST = "localhost";
+  private static final int SERVER_PORT = 8000;
+  private static final String INSTANCE_CONFIGS_PATH = "/CONFIGS/PARTICIPANT";
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  private BrokerMetrics _brokerMetrics;
+
+  @Mock
+  private ServerRoutingStatsManager _serverRoutingStatsManager;
+
+  @Mock
+  private HelixManager _helixManager;
+
+  @Mock
+  private HelixDataAccessor _helixDataAccessor;
+
+  @Mock
+  private BaseDataAccessor<ZNRecord> _zkDataAccessor;
+
+  @Mock
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  @Mock
+  private PropertyKey.Builder _keyBuilder;
+
+  @Mock
+  private PropertyKey _instanceConfigsKey;
+
+  @Mock
+  private Consumer<ServerInstance> _serverReenableCallback;
+
+  private BrokerRoutingManager _routingManager;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+
+    // Set up Helix mocks
+    when(_helixManager.getHelixDataAccessor()).thenReturn(_helixDataAccessor);
+    when(_helixManager.getHelixPropertyStore()).thenReturn(_propertyStore);
+    when(_helixDataAccessor.getBaseDataAccessor()).thenReturn(_zkDataAccessor);
+    when(_helixDataAccessor.keyBuilder()).thenReturn(_keyBuilder);
+    when(_keyBuilder.instanceConfigs()).thenReturn(_instanceConfigsKey);
+    when(_keyBuilder.externalViews()).thenReturn(mock(PropertyKey.class));
+    when(_keyBuilder.idealStates()).thenReturn(mock(PropertyKey.class));
+    when(_instanceConfigsKey.getPath()).thenReturn(INSTANCE_CONFIGS_PATH);
+
+    // Mock paths for external views and ideal states
+    PropertyKey evKey = mock(PropertyKey.class);
+    PropertyKey isKey = mock(PropertyKey.class);
+    when(_keyBuilder.externalViews()).thenReturn(evKey);
+    when(_keyBuilder.idealStates()).thenReturn(isKey);
+    when(evKey.getPath()).thenReturn("/EXTERNALVIEW");
+    when(isKey.getPath()).thenReturn("/IDEALSTATES");
+
+    // Create routing manager
+    _routingManager = new BrokerRoutingManager(_brokerMetrics, _serverRoutingStatsManager, new PinotConfiguration());
+    _routingManager.init(_helixManager);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testNoErrorWhenCallbackNotSet() {
+    // Don't set callback
+
+    // Enable server
+    List<ZNRecord> instanceConfigs = Collections.singletonList(createEnabledServerZNRecord(SERVER_INSTANCE_ID));
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+            anyInt(), anyInt())).thenReturn(instanceConfigs);
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Exclude server
+    _routingManager.excludeServerFromRouting(SERVER_INSTANCE_ID);
+
+    // Disable then re-enable
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+            anyInt(), anyInt())).thenReturn(Collections.emptyList());
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+            anyInt(), anyInt())).thenReturn(instanceConfigs);
+
+    // Should not throw NPE
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Server should be re-enabled in the map
+    assertTrue(_routingManager.getEnabledServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+  }
+
+  @Test
+  public void testServerReenableCallbackInvokedWhenExcludedServerReenabled() {
+    // Set up callback
+    _routingManager.setServerReenableCallback(_serverReenableCallback);
+
+    // First, enable the server by processing instance config change
+    List<ZNRecord> instanceConfigs = Collections.singletonList(createEnabledServerZNRecord(SERVER_INSTANCE_ID));
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+        anyInt(), anyInt())).thenReturn(instanceConfigs);
+
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Verify server is now in enabled map
+    assertTrue(_routingManager.getEnabledServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+
+    // Exclude the server (simulating failure detector marking it unhealthy)
+    _routingManager.excludeServerFromRouting(SERVER_INSTANCE_ID);
+
+    // Now simulate server being disabled then re-enabled (e.g., restart)
+    // First, disable
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+        anyInt(), anyInt())).thenReturn(Collections.emptyList());
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Then re-enable
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+        anyInt(), anyInt())).thenReturn(instanceConfigs);
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Verify callback was invoked with correct ServerInstance
+    ArgumentCaptor<ServerInstance> captor = ArgumentCaptor.forClass(ServerInstance.class);
+    verify(_serverReenableCallback).accept(captor.capture());
+
+    ServerInstance capturedInstance = captor.getValue();
+    assertEquals(capturedInstance.getHostname(), SERVER_HOST);
+    assertEquals(capturedInstance.getPort(), SERVER_PORT);
+  }
+
+  @Test
+  public void testServerReenableCallbackNotInvokedForNewServer() {
+    // Set up callback
+    _routingManager.setServerReenableCallback(_serverReenableCallback);
+
+    // Enable a new server (never excluded)
+    List<ZNRecord> instanceConfigs = Collections.singletonList(createEnabledServerZNRecord(SERVER_INSTANCE_ID));
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT),
+        anyInt(), anyInt())).thenReturn(instanceConfigs);
+
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Verify callback was NOT invoked (server was never excluded)
+    verify(_serverReenableCallback, never()).accept(any());
+  }
+
+  /**
+   * Creates a ZNRecord representing an enabled server instance.
+   */
+  private ZNRecord createEnabledServerZNRecord(String instanceId) {
+    ZNRecord record = new ZNRecord(instanceId);
+    record.setSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name(), "true");
+    record.setSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_HOST.name(),
+        instanceId.split("_")[1]); // Extract host from Server_host_port
+    record.setSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_PORT.name(),
+        instanceId.split("_")[2]); // Extract port from Server_host_port
+    // Don't set IS_SHUTDOWN_IN_PROGRESS or QUERIES_DISABLED (they default to false)
+    return record;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimeUtils.java
@@ -75,8 +75,6 @@ public class DateTimeUtils {
   public static final class DateTimeZoneIndex {
     private static final DateTimeZone[] DATE_TIME_ZONES;
     private static final ISOChronology[] CHRONOLOGIES;
-    private static final int[] FIXED_ZONE_OFFSET;
-    private static final int VARIABLE_ZONE = Integer.MAX_VALUE;
 
     private DateTimeZoneIndex() {
     }
@@ -92,7 +90,6 @@ public class DateTimeUtils {
     static {
       DATE_TIME_ZONES = new DateTimeZone[TimeZoneKey.MAX_TIME_ZONE_KEY + 1];
       CHRONOLOGIES = new ISOChronology[TimeZoneKey.MAX_TIME_ZONE_KEY + 1];
-      FIXED_ZONE_OFFSET = new int[TimeZoneKey.MAX_TIME_ZONE_KEY + 1];
       for (TimeZoneKey timeZoneKey : TimeZoneKey.getTimeZoneKeys()) {
         short zoneKey = timeZoneKey.getKey();
         DateTimeZone dateTimeZone;
@@ -104,11 +101,6 @@ public class DateTimeUtils {
         }
         DATE_TIME_ZONES[zoneKey] = dateTimeZone;
         CHRONOLOGIES[zoneKey] = ISOChronology.getInstance(dateTimeZone);
-        if (dateTimeZone.isFixed() && dateTimeZone.getOffset(0) % 60_000 == 0) {
-          FIXED_ZONE_OFFSET[zoneKey] = dateTimeZone.getOffset(0) / 60_000;
-        } else {
-          FIXED_ZONE_OFFSET[zoneKey] = VARIABLE_ZONE;
-        }
       }
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -182,6 +182,22 @@ public class SegmentZKMetadata implements ZKMetadata {
     setNonNegativeValue(Segment.DATA_CRC, dataCrc);
   }
 
+  public boolean isUseDataCrc() {
+    String useDataCrcString = _simpleFields.get(Segment.USE_DATA_CRC);
+    return Boolean.parseBoolean(useDataCrcString);
+  }
+
+  // useDataCrc is set for consuming segments in realtime table
+  // that signal replica server to use Data CRC when available for doing any replacement
+  // of segments
+  public void setUseDataCrc(boolean useDataCrc) {
+    if (useDataCrc) {
+      _simpleFields.put(Segment.USE_DATA_CRC, "true");
+    } else {
+      _simpleFields.remove(Segment.USE_DATA_CRC);
+    }
+  }
+
   public String getTier() {
     return _simpleFields.get(Segment.TIER);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtils.java
@@ -94,6 +94,10 @@ public class SegmentZKMetadataUtils {
 
       segmentZKMetadata.setEndOffset(endOffset);
       segmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+      // for committing segments, we use data CRC to replace but only if the data CRC is present for the segment
+      if (Long.parseLong(segmentMetadata.getDataCrc()) >= 0) {
+        segmentZKMetadata.setUseDataCrc(true);
+      }
 
       // For committing segment, use current time as start/end time if total docs is 0
       if (segmentMetadata.getTotalDocs() > 0) {
@@ -110,7 +114,9 @@ public class SegmentZKMetadataUtils {
       segmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);
     } else {
       // For uploaded segment
-
+      // clear the use data crc flag for uploaded segments
+      // This flag should ONLY be true for segments committed from CONSUMING state
+      segmentZKMetadata.setUseDataCrc(false);
       // Set segment status, start/end offset info for real-time table
       if (TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
         segmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.UPLOADED);

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -24,9 +24,11 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.metrics.PinotMeter;
+
 
 /**
- * Class containing all the metrics exposed by the Pinot broker.
+ * Class containing all the meters exposed by the Pinot broker.
  * This is implemented as a class rather than an enum to allow for dynamic addition of metrics for all QueryErrorCodes.
  */
 public class BrokerMeter implements AbstractMetrics.Meter {
@@ -236,6 +238,11 @@ public class BrokerMeter implements AbstractMetrics.Meter {
    */
   public static final BrokerMeter WINDOW_COUNT = create("WINDOW_COUNT", "queries", true);
 
+  public static final BrokerMeter MSE_STAGES_STARTED = create("MSE_STAGES_STARTED", "stages", true);
+  public static final BrokerMeter MSE_STAGES_COMPLETED = create("MSE_STAGES_COMPLETED", "stages", true);
+  public static final BrokerMeter MSE_OPCHAINS_STARTED = create("MSE_OPCHAINS_STARTED", "opchains", true);
+  public static final BrokerMeter MSE_OPCHAINS_COMPLETED = create("MSE_OPCHAINS_COMPLETED", "opchains", true);
+
   /**
    * How many MSE queries have encountered segments with invalid partitions.
    * <p>
@@ -346,5 +353,9 @@ public class BrokerMeter implements AbstractMetrics.Meter {
 
   public static BrokerMeter getQueryErrorMeter(QueryErrorCode queryErrorCode) {
     return QUERY_ERROR_CODE_METER_MAP.get(queryErrorCode);
+  }
+
+  public PinotMeter getGlobalMeter() {
+    return BrokerMetrics.get().getMeteredValue(this);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -285,6 +285,12 @@ public class BrokerMeter implements AbstractMetrics.Meter {
    */
   public static final BrokerMeter QUERY_RESPONSE_SIZE_BYTES = create("QUERY_RESPONSE_SIZE_BYTES", "bytes", true);
 
+  /**
+   * SLA-style per-query error classification metrics.
+   */
+  public static final BrokerMeter QUERY_CRITICAL_ERROR = create("QUERY_CRITICAL_ERROR", "queries", true);
+  public static final BrokerMeter QUERY_NON_CRITICAL_ERROR = create("QUERY_NON_CRITICAL_ERROR", "queries", true);
+
   private static final Map<QueryErrorCode, BrokerMeter> QUERY_ERROR_CODE_METER_MAP;
 
   // Iterate through all query error codes from QueryErrorCode.getAllValues() and create a metric for each

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -81,7 +81,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   // Audit logging metrics
   AUDIT_REQUEST_FAILURES("failures", true),
   AUDIT_RESPONSE_FAILURES("failures", true),
-  AUDIT_REQUEST_PAYLOAD_TRUNCATED("count", true);
+  AUDIT_REQUEST_PAYLOAD_TRUNCATED("count", true),
+  // Upsert compact merge task metrics
+  UPSERT_COMPACT_MERGE_SEGMENT_SKIPPED_CONSENSUS_FAILURE("UpsertCompactMergeSegmentsSkipped", false);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.metrics;
 
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.spi.metrics.PinotMeter;
 
 
 /**
@@ -246,7 +247,24 @@ public enum ServerMeter implements AbstractMetrics.Meter {
 
   TRANSFORMATION_ERROR_COUNT("rows", false),
   DROPPED_RECORD_COUNT("rows", false),
-  CORRUPTED_RECORD_COUNT("rows", false);
+  CORRUPTED_RECORD_COUNT("rows", false),
+
+  /// Number of multi-stage execution opchains started.
+  /// This is equal to the number of stages times the average parallelism
+  MSE_OPCHAINS_STARTED("opchains", true),
+  /// Number of multi-stage execution opchains completed.
+  /// This is equal to the number of stages times the average parallelism
+  MSE_OPCHAINS_COMPLETED("opchains", true),
+
+  /// Total execution time spent in multi-stage execution on CPU in milliseconds.
+  /// This is equal to the sum of the executionTimeMs reported by the root of all the opchains executed in the server.
+  MSE_CPU_EXECUTION_TIME_MS("milliseconds", true),
+  /// Total memory allocated in bytes for multi-stage execution.
+  /// This is equal to the sum of the allocatedMemoryBytes reported by all the opchains executed in the server.
+  MSE_MEMORY_ALLOCATED_BYTES("bytes", true),
+  /// Total number of rows emitted by multi-stage execution.
+  /// This is equal to the sum of the emittedRows reported by the root of all the opchains executed in the server.
+  MSE_EMITTED_ROWS("rows", true);
 
   private final String _meterName;
   private final String _unit;
@@ -287,5 +305,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   @Override
   public String getDescription() {
     return _description;
+  }
+
+  public PinotMeter getGlobalMeter() {
+    return ServerMetrics.get().getMeteredValue(this);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -76,6 +76,8 @@ public interface BrokerResponse {
    * This method ensures we emit metrics for all queries that have exceptions with a one-to-one mapping.
    */
   default void emitBrokerResponseMetrics(BrokerMetrics brokerMetrics) {
+    boolean hasCriticalError = false;
+    boolean hasNonCriticalError = false;
     for (QueryProcessingException exception : this.getExceptions()) {
       QueryErrorCode queryErrorCode;
       try {
@@ -85,6 +87,18 @@ public interface BrokerResponse {
         queryErrorCode = QueryErrorCode.UNKNOWN;
       }
       brokerMetrics.addMeteredGlobalValue(BrokerMeter.getQueryErrorMeter(queryErrorCode), 1);
+      if (queryErrorCode.isCriticalError()) {
+        hasCriticalError = true;
+      } else {
+        hasNonCriticalError = true;
+      }
+    }
+    // Emit exactly one SLA-style metric per query if there are any exceptions
+    if (hasCriticalError) {
+      brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_CRITICAL_ERROR, 1);
+    }
+    if (hasNonCriticalError) {
+      brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_NON_CRITICAL_ERROR, 1);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/mapper/TimeSeriesResponseMapper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/mapper/TimeSeriesResponseMapper.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.tsdb.spi.series.TimeSeries;
 import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
 
@@ -158,6 +159,32 @@ public class TimeSeriesResponseMapper {
     map.merge(BrokerResponseNativeV2.StatKey.TOTAL_DOCS,
         getLongMetadataValue(metadata, DataTable.MetadataKey.TOTAL_DOCS));
     brokerResponse.addBrokerStats(map);
+  }
+
+  public static void setStatsInRequestContext(RequestContext requestContext, Map<String, String> metadata) {
+    if (metadata == null || metadata.isEmpty() || requestContext == null) {
+      return;
+    }
+    requestContext.setNumDocsScanned(getLongMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_DOCS_SCANNED));
+    requestContext.setNumEntriesScannedInFilter(getLongMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_ENTRIES_SCANNED_IN_FILTER));
+    requestContext.setNumEntriesScannedPostFilter(getLongMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_ENTRIES_SCANNED_POST_FILTER));
+    requestContext.setTotalDocs(getLongMetadataValue(metadata,
+        DataTable.MetadataKey.TOTAL_DOCS));
+    requestContext.setNumSegmentsQueried(getIntMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_SEGMENTS_QUERIED));
+    requestContext.setNumSegmentsProcessed(getIntMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_SEGMENTS_PROCESSED));
+    requestContext.setNumSegmentsMatched(getIntMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_SEGMENTS_MATCHED));
+    requestContext.setNumConsumingSegmentsMatched(getIntMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_CONSUMING_SEGMENTS_MATCHED));
+    requestContext.setNumConsumingSegmentsProcessed(getIntMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_CONSUMING_SEGMENTS_PROCESSED));
+    requestContext.setNumConsumingSegmentsQueried(getIntMetadataValue(metadata,
+        DataTable.MetadataKey.NUM_CONSUMING_SEGMENTS_QUERIED));
   }
 
   private static long getLongMetadataValue(Map<String, String> metadata, DataTable.MetadataKey key) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
@@ -27,67 +27,67 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.spi.config.user.AccessType;
 import org.apache.pinot.spi.config.user.UserConfig;
 
+
 /**
  * UserConfigUtils is responsible for two things:
  * 1. Used to acquire user config by parsing znRecord that stored in Zookeeper
  * 2. Used to construct znRecord by packaging user config
  */
 public class AccessControlUserConfigUtils {
-    private AccessControlUserConfigUtils() {
+  private AccessControlUserConfigUtils() {
+  }
+
+  public static UserConfig fromZNRecord(ZNRecord znRecord) {
+    Map<String, String> simpleFields = znRecord.getSimpleFields();
+
+    // Mandatory fields
+    String username = simpleFields.get(UserConfig.USERNAME_KEY);
+    String password = simpleFields.get(UserConfig.PASSWORD_KEY);
+    String component = simpleFields.get(UserConfig.COMPONET_KEY);
+    String role = simpleFields.get(UserConfig.ROLE_KEY);
+
+    List<String> tableList = znRecord.getListField(UserConfig.TABLES_KEY);
+    List<String> excludeTableList = znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY);
+
+    List<String> permissionListFromZNRecord = znRecord.getListField(UserConfig.PERMISSIONS_KEY);
+    List<AccessType> permissionList = null;
+    if (permissionListFromZNRecord != null) {
+      permissionList = permissionListFromZNRecord.stream().map(x -> AccessType.valueOf(x)).collect(Collectors.toList());
+    }
+    return new UserConfig(username, password, component, role, tableList, excludeTableList, permissionList);
+  }
+
+  public static ZNRecord toZNRecord(UserConfig userConfig)
+      throws JsonProcessingException {
+    Map<String, String> simpleFields = new HashMap<>();
+
+    // Mandatory fields
+    simpleFields.put(UserConfig.USERNAME_KEY, userConfig.getUserName());
+    simpleFields.put(UserConfig.PASSWORD_KEY, userConfig.getPassword());
+    simpleFields.put(UserConfig.COMPONET_KEY, userConfig.getComponentType().toString());
+    simpleFields.put(UserConfig.ROLE_KEY, userConfig.getRoleType().toString());
+
+    Map<String, List<String>> listFields = new HashMap<>();
+
+    // Optional fields
+    List<String> tableList = userConfig.getTables();
+    if (tableList != null) {
+      listFields.put(UserConfig.TABLES_KEY, userConfig.getTables());
+    }
+    List<String> excludeTableList = userConfig.getExcludeTables();
+    if (excludeTableList != null) {
+      listFields.put(UserConfig.EXCLUDE_TABLES_KEY, userConfig.getExcludeTables());
     }
 
-    public static UserConfig fromZNRecord(ZNRecord znRecord) {
-        Map<String, String> simpleFields = znRecord.getSimpleFields();
-
-        // Mandatory fields
-        String username = simpleFields.get(UserConfig.USERNAME_KEY);
-        String password = simpleFields.get(UserConfig.PASSWORD_KEY);
-        String component = simpleFields.get(UserConfig.COMPONET_KEY);
-        String role = simpleFields.get(UserConfig.ROLE_KEY);
-
-        List<String> tableList = znRecord.getListField(UserConfig.TABLES_KEY);
-        List<String> excludeTableList = znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY);
-
-        List<String> permissionListFromZNRecord = znRecord.getListField(UserConfig.PERMISSIONS_KEY);
-        List<AccessType> permissionList = null;
-        if (permissionListFromZNRecord != null) {
-            permissionList = permissionListFromZNRecord.stream()
-                .map(x -> AccessType.valueOf(x)).collect(Collectors.toList());
-        }
-        return new UserConfig(username, password, component, role, tableList, excludeTableList, permissionList);
+    List<AccessType> permissionList = userConfig.getPermissios();
+    if (permissionList != null) {
+      listFields.put(UserConfig.PERMISSIONS_KEY,
+          userConfig.getPermissios().stream().map(e -> e.toString()).collect(Collectors.toList()));
     }
 
-    public static ZNRecord toZNRecord(UserConfig userConfig)
-        throws JsonProcessingException {
-        Map<String, String> simpleFields = new HashMap<>();
-
-        // Mandatory fields
-        simpleFields.put(UserConfig.USERNAME_KEY, userConfig.getUserName());
-        simpleFields.put(UserConfig.PASSWORD_KEY, userConfig.getPassword());
-        simpleFields.put(UserConfig.COMPONET_KEY, userConfig.getComponentType().toString());
-        simpleFields.put(UserConfig.ROLE_KEY, userConfig.getRoleType().toString());
-
-        Map<String, List<String>> listFields = new HashMap<>();
-
-        // Optional fields
-        List<String> tableList = userConfig.getTables();
-        if (tableList != null) {
-            listFields.put(UserConfig.TABLES_KEY, userConfig.getTables());
-        }
-        List<String> excludeTableList = userConfig.getExcludeTables();
-        if (excludeTableList != null) {
-            listFields.put(UserConfig.EXCLUDE_TABLES_KEY, userConfig.getExcludeTables());
-        }
-
-        List<AccessType> permissionList = userConfig.getPermissios();
-        if (permissionList != null) {
-            listFields.put(UserConfig.PERMISSIONS_KEY, userConfig.getPermissios().stream()
-                .map(e -> e.toString()).collect(Collectors.toList()));
-        }
-
-        ZNRecord znRecord = new ZNRecord(userConfig.getUserName());
-        znRecord.setSimpleFields(simpleFields);
-        znRecord.setListFields(listFields);
-        return znRecord;
-    }
+    ZNRecord znRecord = new ZNRecord(userConfig.getUserName());
+    znRecord.setSimpleFields(simpleFields);
+    znRecord.setListFields(listFields);
+    return znRecord;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
@@ -79,10 +79,10 @@ public class AccessControlUserConfigUtils {
       listFields.put(UserConfig.EXCLUDE_TABLES_KEY, userConfig.getExcludeTables());
     }
 
-    List<AccessType> permissionList = userConfig.getPermissios();
+    List<AccessType> permissionList = userConfig.getPermissions();
     if (permissionList != null) {
       listFields.put(UserConfig.PERMISSIONS_KEY,
-          userConfig.getPermissios().stream().map(e -> e.toString()).collect(Collectors.toList()));
+          userConfig.getPermissions().stream().map(e -> e.toString()).collect(Collectors.toList()));
     }
 
     ZNRecord znRecord = new ZNRecord(userConfig.getUserName());

--- a/pinot-common/src/main/resources/zone-index.properties
+++ b/pinot-common/src/main/resources/zone-index.properties
@@ -1731,6 +1731,7 @@
 1704 Africa/Gaborone
 1705 Africa/Harare
 1706 Africa/Johannesburg
+1707 Africa/Juba
 1708 Africa/Kampala
 1709 Africa/Khartoum
 1710 Africa/Kigali
@@ -1961,6 +1962,7 @@
 1935 Asia/Dushanbe
 1936 Asia/Gaza
 1937 Asia/Harbin
+1938 Asia/Hebron
 1939 Asia/Ho_Chi_Minh
 1940 Asia/Hong_Kong
 1941 Asia/Hovd
@@ -2196,7 +2198,7 @@
 2171 US/Michigan
 2172 US/Mountain
 2173 US/Pacific
-# 2174 US/Pacific-New # not in joda-time
+# 2174 US/Pacific-New removed http://mm.icann.org/pipermail/tz-announce/2020-October/000059.html
 2175 US/Samoa
 2176 CET
 2177 CST6CDT
@@ -2232,3 +2234,27 @@
 2207 Turkey
 2208 W-SU
 2209 WET
+2210 America/Creston
+2211 Antarctica/Troll
+2212 Asia/Khandyga
+2213 Asia/Ust-Nera
+2214 Europe/Busingen
+2215 Asia/Chita
+2216 Asia/Srednekolymsk
+2217 Pacific/Bougainville
+2218 America/Fort_Nelson
+2219 Asia/Barnaul
+2220 Asia/Tomsk
+2221 Europe/Astrakhan
+2222 Europe/Kirov
+2223 Europe/Ulyanovsk
+2224 Asia/Yangon
+2225 America/Punta_Arenas
+2226 Asia/Atyrau
+2227 Asia/Famagusta
+2228 Europe/Saratov
+2229 Asia/Qostanay
+2230 America/Nuuk
+2231 Pacific/Kanton
+2232 Europe/Kyiv
+2233 America/Ciudad_Juarez

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -130,6 +130,7 @@ import org.apache.pinot.controller.validation.ResourceUtilizationChecker;
 import org.apache.pinot.controller.validation.ResourceUtilizationManager;
 import org.apache.pinot.controller.validation.StorageQuotaChecker;
 import org.apache.pinot.controller.validation.UtilizationChecker;
+import org.apache.pinot.core.data.manager.realtime.UpsertInconsistentStateConfig;
 import org.apache.pinot.core.periodictask.PeriodicTask;
 import org.apache.pinot.core.periodictask.PeriodicTaskScheduler;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
@@ -727,6 +728,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _serviceStatusCallbackList.add(generateServiceStatusCallback(_helixParticipantManager));
 
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(ContinuousJfrStarter.INSTANCE);
+    _clusterConfigChangeHandler.registerClusterConfigChangeListener(UpsertInconsistentStateConfig.getInstance());
+    LOGGER.info("Registered UpsertInconsistentStateConfig as cluster config change listener");
   }
 
   protected PinotLLCRealtimeSegmentManager createPinotLLCRealtimeSegmentManager() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -1001,7 +1001,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   /**
    * Creates a TaskManager instance  as specified in the configuration.
    */
-  private PinotTaskManager createTaskManager() {
+  protected PinotTaskManager createTaskManager() {
     String taskManagerClass = _config.getProperty(CommonConstants.Controller.CONFIG_OF_TASK_MANAGER_CLASS,
         CommonConstants.Controller.DEFAULT_TASK_MANAGER_CLASS);
     LOGGER.info("Creating TaskManager with class: {}", taskManagerClass);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -112,6 +112,8 @@ import org.apache.pinot.controller.helix.core.rebalance.TableRebalanceManager;
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalanceChecker;
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalancer;
 import org.apache.pinot.controller.helix.core.relocation.SegmentRelocator;
+import org.apache.pinot.controller.helix.core.replication.RealtimeSegmentCopier;
+import org.apache.pinot.controller.helix.core.replication.TableReplicator;
 import org.apache.pinot.controller.helix.core.retention.RetentionManager;
 import org.apache.pinot.controller.helix.core.statemodel.LeadControllerResourceMasterSlaveStateModelFactory;
 import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
@@ -218,6 +220,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected TaskMetricsEmitter _taskMetricsEmitter;
   protected PoolingHttpClientConnectionManager _connectionManager;
   protected TenantRebalancer _tenantRebalancer;
+  protected TableReplicator _tableReplicator;
   // This executor should be used by all code paths for user initiated rebalances, so that the controller config
   // CONTROLLER_EXECUTOR_REBALANCE_NUM_THREADS is honored.
   protected ExecutorService _rebalancerExecutorService;
@@ -617,6 +620,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
             _rebalancerExecutorService);
     _tenantRebalancer =
         new TenantRebalancer(_tableRebalanceManager, _helixResourceManager, _rebalancerExecutorService);
+    _tableReplicator = new TableReplicator(_helixResourceManager, _executorService, new RealtimeSegmentCopier(_config));
 
     // Setting up periodic tasks
     List<PeriodicTask> controllerPeriodicTasks = setupControllerPeriodicTasks();
@@ -678,6 +682,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_sqlQueryExecutor).to(SqlQueryExecutor.class);
         bind(_pinotLLCRealtimeSegmentManager).to(PinotLLCRealtimeSegmentManager.class);
         bind(_tenantRebalancer).to(TenantRebalancer.class);
+        bind(_tableReplicator).to(TableReplicator.class);
         bind(_tableSizeReader).to(TableSizeReader.class);
         bind(_storageQuotaChecker).to(StorageQuotaChecker.class);
         bind(_diskUtilizationChecker).to(DiskUtilizationChecker.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -405,6 +405,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONFIG_OF_MAX_TENANT_REBALANCE_JOBS_IN_ZK = "controller.tenant.rebalance.maxJobsInZK";
   public static final String CONFIG_OF_MAX_RELOAD_SEGMENT_JOBS_IN_ZK = "controller.reload.segment.maxJobsInZK";
   public static final String CONFIG_OF_MAX_FORCE_COMMIT_JOBS_IN_ZK = "controller.force.commit.maxJobsInZK";
+  public static final String CONFIG_OF_MAX_TABLE_REPLICATION_JOBS_IN_ZK = "controller.table.replication.maxJobsInZK";
 
   private final Map<String, String> _invalidConfigs = new ConcurrentHashMap<>();
 
@@ -1400,5 +1401,9 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean getSegmentCompletionGroupCommitEnabled() {
     return getProperty(CONTROLLER_SEGMENT_COMPLETION_GROUP_COMMIT_ENABLED, true);
+  }
+
+  public int getMaxTableReplicationZkJobs() {
+    return getProperty(CONFIG_OF_MAX_FORCE_COMMIT_JOBS_IN_ZK, ControllerJob.DEFAULT_MAXIMUM_CONTROLLER_JOBS_IN_ZK);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/UserAlreadyExistsException.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/UserAlreadyExistsException.java
@@ -19,11 +19,12 @@
 package org.apache.pinot.controller.api.exception;
 
 public class UserAlreadyExistsException extends RuntimeException {
-    public UserAlreadyExistsException(String message) {
-        super(message);
-    }
 
-    public UserAlreadyExistsException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public UserAlreadyExistsException(String message) {
+    super(message);
+  }
+
+  public UserAlreadyExistsException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
   public static final String SCHEMA_TAG = "Schema";
   public static final String TENANT_TAG = "Tenant";
   public static final String BROKER_TAG = "Broker";
+  public static final String MINION_TAG = "Minion";
   public static final String SEGMENT_TAG = "Segment";
   public static final String TASK_TAG = "Task";
   public static final String LEAD_CONTROLLER_TAG = "Leader";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -25,11 +25,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+/**
+ * Payload for the copy table request.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CopyTablePayload {
 
   private String _sourceClusterUri;
   private Map<String, String> _headers;
+
+  private String _destinationClusterUri;
+  private Map<String, String> _destinationClusterHeaders;
   /**
    * Broker tenant for the new table.
    * MUST NOT contain the tenant type suffix, i.e. _BROKER.
@@ -51,11 +57,15 @@ public class CopyTablePayload {
   public CopyTablePayload(
       @JsonProperty(value = "sourceClusterUri", required = true) String sourceClusterUri,
       @JsonProperty("sourceClusterHeaders") Map<String, String> headers,
+      @JsonProperty(value = "destinationClusterUri", required = true) String destinationClusterUri,
+      @JsonProperty(value = "destinationClusterHeaders") Map<String, String> destinationClusterHeaders,
       @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
       @JsonProperty(value = "serverTenant", required = true) String serverTenant,
       @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap) {
     _sourceClusterUri = sourceClusterUri;
     _headers = headers;
+    _destinationClusterUri = destinationClusterUri;
+    _destinationClusterHeaders = destinationClusterHeaders;
     _brokerTenant = brokerTenant;
     _serverTenant = serverTenant;
     _tagPoolReplacementMap = tagPoolReplacementMap;
@@ -69,6 +79,16 @@ public class CopyTablePayload {
   @JsonGetter("sourceClusterHeaders")
   public Map<String, String> getHeaders() {
     return _headers;
+  }
+
+  @JsonGetter("destinationClusterUri")
+  public String getDestinationClusterUri() {
+    return _sourceClusterUri;
+  }
+
+  @JsonGetter("destinationClusterHeaders")
+  public Map<String, String> getDestinationClusterHeaders() {
+    return _destinationClusterHeaders;
   }
 
   @JsonGetter("brokerTenant")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -83,7 +83,7 @@ public class CopyTablePayload {
 
   @JsonGetter("destinationClusterUri")
   public String getDestinationClusterUri() {
-    return _sourceClusterUri;
+    return _destinationClusterUri;
   }
 
   @JsonGetter("destinationClusterHeaders")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CopyTablePayload {
+
+  private String _sourceClusterUri;
+  private Map<String, String> _headers;
+  /**
+   * Broker tenant for the new table.
+   * MUST NOT contain the tenant type suffix, i.e. _BROKER.
+   */
+  private String _brokerTenant;
+  /**
+   * Server tenant for the new table.
+   * MUST NOT contain the tenant type suffix, i.e. _REALTIME or _OFFLINE.
+   */
+  private String _serverTenant;
+
+  /**
+   * The instanceAssignmentConfig's tagPoolConfig contains full tenant name. We will use this field to let user specify
+   * the replacement relation from source cluster's full tenant to target cluster's full tenant.
+   */
+  private Map<String, String> _tagPoolReplacementMap;
+
+  @JsonCreator
+  public CopyTablePayload(
+      @JsonProperty(value = "sourceClusterUri", required = true) String sourceClusterUri,
+      @JsonProperty("sourceClusterHeaders") Map<String, String> headers,
+      @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
+      @JsonProperty(value = "serverTenant", required = true) String serverTenant,
+      @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap) {
+    _sourceClusterUri = sourceClusterUri;
+    _headers = headers;
+    _brokerTenant = brokerTenant;
+    _serverTenant = serverTenant;
+    _tagPoolReplacementMap = tagPoolReplacementMap;
+  }
+
+  @JsonGetter("sourceClusterUri")
+  public String getSourceClusterUri() {
+    return _sourceClusterUri;
+  }
+
+  @JsonGetter("sourceClusterHeaders")
+  public Map<String, String> getHeaders() {
+    return _headers;
+  }
+
+  @JsonGetter("brokerTenant")
+  public String getBrokerTenant() {
+    return _brokerTenant;
+  }
+
+  @JsonGetter("serverTenant")
+  public String getServerTenant() {
+    return _serverTenant;
+  }
+
+  @JsonGetter("tagPoolReplacementMap")
+  public Map<String, String> getTagPoolReplacementMap() {
+    return _tagPoolReplacementMap;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CopyTableResponse {
+  @JsonProperty("msg")
+  private String _msg;
+
+  @JsonProperty("status")
+  private String _status;
+
+  @JsonProperty("schema")
+  private Schema _schema;
+
+  @JsonProperty("realtimeTableConfig")
+  private TableConfig _tableConfig;
+
+  @JsonProperty("watermarkInductionResult")
+  private WatermarkInductionResult _watermarkInductionResult;
+
+  @JsonCreator
+  public CopyTableResponse(@JsonProperty("status") String status, @JsonProperty("msg") String msg,
+      @JsonProperty("schema") @Nullable Schema schema,
+      @JsonProperty("realtimeTableConfig") @Nullable TableConfig tableConfig,
+      @JsonProperty("watermarkInductionResult") @Nullable WatermarkInductionResult watermarkInductionResult) {
+    _status = status;
+    _msg = msg;
+    _schema = schema;
+    _tableConfig = tableConfig;
+    _watermarkInductionResult = watermarkInductionResult;
+  }
+
+  public String getMsg() {
+    return _msg;
+  }
+
+  public void setMsg(String msg) {
+    _msg = msg;
+  }
+
+  public String getStatus() {
+    return _status;
+  }
+
+  public void setStatus(String status) {
+    _status = status;
+  }
+
+  public Schema getSchema() {
+    return _schema;
+  }
+
+  public void setSchema(Schema schema) {
+    _schema = schema;
+  }
+
+  public TableConfig getTableConfig() {
+    return _tableConfig;
+  }
+
+  public void setTableConfig(TableConfig tableConfig) {
+    _tableConfig = tableConfig;
+  }
+
+  public WatermarkInductionResult getWatermarkInductionResult() {
+    return _watermarkInductionResult;
+  }
+
+  public void setWatermarkInductionResult(
+      WatermarkInductionResult watermarkInductionResult) {
+    _watermarkInductionResult = watermarkInductionResult;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/MinionStatusResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/MinionStatusResponse.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+
+/**
+ * Response object for the GET /minions/status endpoint.
+ * Provides status information for all minion instances including their task counts and drain state.
+ */
+public class MinionStatusResponse {
+  private int _currentMinionCount;
+  private List<MinionStatus> _minionStatus;
+
+  public MinionStatusResponse() {
+  }
+
+  public MinionStatusResponse(int currentMinionCount, List<MinionStatus> minionStatus) {
+    _currentMinionCount = currentMinionCount;
+    _minionStatus = minionStatus;
+  }
+
+  @JsonProperty("currentMinionCount")
+  public int getCurrentMinionCount() {
+    return _currentMinionCount;
+  }
+
+  public void setCurrentMinionCount(int currentMinionCount) {
+    _currentMinionCount = currentMinionCount;
+  }
+
+  @JsonProperty("minionStatus")
+  public List<MinionStatus> getMinionStatus() {
+    return _minionStatus;
+  }
+
+  public void setMinionStatus(List<MinionStatus> minionStatus) {
+    _minionStatus = minionStatus;
+  }
+
+  /**
+   * Status information for a single minion instance.
+   */
+  public static class MinionStatus {
+    private String _instanceId;
+    private String _host;
+    private int _port;
+    private int _runningTaskCount;
+    private String _status;
+
+    public MinionStatus() {
+    }
+
+    public MinionStatus(String instanceId, String host, int port, int runningTaskCount, String status) {
+      _instanceId = instanceId;
+      _host = host;
+      _port = port;
+      _runningTaskCount = runningTaskCount;
+      _status = status;
+    }
+
+    @JsonProperty("instanceId")
+    public String getInstanceId() {
+      return _instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+      _instanceId = instanceId;
+    }
+
+    @JsonProperty("host")
+    public String getHost() {
+      return _host;
+    }
+
+    public void setHost(String host) {
+      _host = host;
+    }
+
+    @JsonProperty("port")
+    public int getPort() {
+      return _port;
+    }
+
+    public void setPort(int port) {
+      _port = port;
+    }
+
+    @JsonProperty("runningTaskCount")
+    public int getRunningTaskCount() {
+      return _runningTaskCount;
+    }
+
+    public void setRunningTaskCount(int runningTaskCount) {
+      _runningTaskCount = runningTaskCount;
+    }
+
+    @JsonProperty("status")
+    public String getStatus() {
+      return _status;
+    }
+
+    public void setStatus(String status) {
+      _status = status;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
@@ -67,166 +67,162 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
     description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```")))
 @Path("/")
 public class PinotAccessControlUserRestletResource {
-    /**
-     * URI Mappings:
-     * - "/user", "/users/": List all the users
-     * - "/users/{username}", "/users/{username}/": List config for specified username.
-     *
-     * - "/user", "/users/" : Add a user
-     * <pre>
-     *       POST Request Body Example :
-     *        {
-     *         "username": "user1",
-     *         "password": "user1@passwd",
-     *         "component": "BROKER",
-     *         "role" : "ADMIN",
-     *         "tables": ["table1", "table2"],
-     *         "permissions": ["READ"]
-     *        }
-     *  </pre>
-     *
-     *  - "/users/{username}", "/users/{username}/"
-     *  PUT Request body example : same as POST Request Body
-     * {@inheritDoc}
-     */
-    public static final Logger LOGGER = LoggerFactory.getLogger(PinotAccessControlUserRestletResource.class);
+  /**
+   * URI Mappings:
+   * - "/user", "/users/": List all the users
+   * - "/users/{username}", "/users/{username}/": List config for specified username.
+   *
+   * - "/user", "/users/" : Add a user
+   * <pre>
+   *       POST Request Body Example :
+   *        {
+   *         "username": "user1",
+   *         "password": "user1@passwd",
+   *         "component": "BROKER",
+   *         "role" : "ADMIN",
+   *         "tables": ["table1", "table2"],
+   *         "permissions": ["READ"]
+   *        }
+   *  </pre>
+   *
+   *  - "/users/{username}", "/users/{username}/"
+   *  PUT Request body example : same as POST Request Body
+   * {@inheritDoc}
+   */
+  public static final Logger LOGGER = LoggerFactory.getLogger(PinotAccessControlUserRestletResource.class);
 
-    @Inject
-    PinotHelixResourceManager _pinotHelixResourceManager;
+  @Inject
+  PinotHelixResourceManager _pinotHelixResourceManager;
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("/users")
-    @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_USER)
-    @ApiOperation(value = "List all uses in cluster", notes = "List all users in cluster")
-    public String listUsers() {
-        try {
-            ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
-            Map<String, UserConfig> allUserInfo = ZKMetadataProvider.getAllUserInfo(propertyStore);
-            return JsonUtils.newObjectNode().set("users", JsonUtils.objectToJsonNode(allUserInfo)).toString();
-        } catch (Exception e) {
-            throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
-        }
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/users")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_USER)
+  @ApiOperation(value = "List all uses in cluster", notes = "List all users in cluster")
+  public String listUsers() {
+    try {
+      ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+      Map<String, UserConfig> allUserInfo = ZKMetadataProvider.getAllUserInfo(propertyStore);
+      return JsonUtils.newObjectNode().set("users", JsonUtils.objectToJsonNode(allUserInfo)).toString();
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/users/{username}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_USER)
+  @ApiOperation(value = "Get an user in cluster", notes = "Get an user in cluster")
+  public String getUser(@PathParam("username") String username,
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
+    try {
+      ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+      ComponentType componentType = Constants.validateComponentType(componentTypeStr);
+      String usernameWithType = username + "_" + componentType.name();
+
+      UserConfig userConfig = ZKMetadataProvider.getUserConfig(propertyStore, usernameWithType);
+      return JsonUtils.newObjectNode().set(usernameWithType, JsonUtils.objectToJsonNode(userConfig)).toString();
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
+    }
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/users")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.CREATE_USER)
+  @ApiOperation(value = "Add a user", notes = "Add a user")
+  public SuccessResponse addUser(String userConfigStr) {
+    // TODO introduce a table config ctor with json string.
+
+    UserConfig userConfig;
+    String username;
+    try {
+      userConfig = JsonUtils.stringToObject(userConfigStr, UserConfig.class);
+      username = userConfig.getUserName();
+      if (username.contains(".") || username.contains(" ")) {
+        throw new IllegalStateException("Username: " + username + " containing '.' or space is not allowed");
+      }
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
+    }
+    try {
+      _pinotHelixResourceManager.addUser(userConfig);
+      return new SuccessResponse(
+          "User " + userConfig.getUserName() + '_' + userConfig.getComponentType() + " has been successfully added!");
+    } catch (Exception e) {
+      if (e instanceof UserAlreadyExistsException) {
+        throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
+      } else {
+        throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
+      }
+    }
+  }
+
+  @DELETE
+  @Path("/users/{username}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DELETE_USER)
+  @Authenticate(AccessType.DELETE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Delete a user", notes = "Delete a user")
+  public SuccessResponse deleteUser(@PathParam("username") String username,
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
+
+    List<String> usersDeleted = new LinkedList<>();
+    String usernameWithComponentType = username + "_" + componentTypeStr;
+
+    try {
+
+      boolean userExist = false;
+      userExist = _pinotHelixResourceManager.hasUser(username, componentTypeStr);
+
+      _pinotHelixResourceManager.deleteUser(usernameWithComponentType);
+      if (userExist) {
+        usersDeleted.add(username);
+      }
+      if (!usersDeleted.isEmpty()) {
+        return new SuccessResponse("User: " + usernameWithComponentType + " has been successfully deleted");
+      }
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("/users/{username}")
-    @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_USER)
-    @ApiOperation(value = "Get an user in cluster", notes = "Get an user in cluster")
-    public String getUser(@PathParam("username") String username,
-        @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
-        try {
-            ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
-            ComponentType componentType = Constants.validateComponentType(componentTypeStr);
-            String usernameWithType = username + "_" + componentType.name();
+    throw new ControllerApplicationException(LOGGER, "User " + usernameWithComponentType + " does not exists",
+        Response.Status.NOT_FOUND);
+  }
 
-            UserConfig userConfig = ZKMetadataProvider.getUserConfig(propertyStore, usernameWithType);
-            return JsonUtils.newObjectNode().set(usernameWithType, JsonUtils.objectToJsonNode(userConfig)).toString();
-        } catch (Exception e) {
-            throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
-        }
-    }
+  @PUT
+  @Path("/users/{username}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.UPDATE_USER)
+  @Authenticate(AccessType.UPDATE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Update user config for a user", notes = "Update user config for user")
+  public SuccessResponse updateUserConfig(@PathParam("username") String username,
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr,
+      @QueryParam("passwordChanged") boolean passwordChanged, String userConfigString) {
 
-    @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("/users")
-    @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.CREATE_USER)
-    @ApiOperation(value = "Add a user", notes = "Add a user")
-    public SuccessResponse addUser(String userConfigStr) {
-        // TODO introduce a table config ctor with json string.
-
-        UserConfig userConfig;
-        String username;
-        try {
-            userConfig = JsonUtils.stringToObject(userConfigStr, UserConfig.class);
-            username = userConfig.getUserName();
-            if (username.contains(".") || username.contains(" ")) {
-                throw new IllegalStateException("Username: " + username + " containing '.' or space is not allowed");
-            }
-        } catch (Exception e) {
-            throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
-        }
-        try {
-            _pinotHelixResourceManager.addUser(userConfig);
-            return new SuccessResponse("User " + userConfig.getUserName() + '_' + userConfig.getComponentType()
-                + " has been successfully added!");
-        } catch (Exception e) {
-            if (e instanceof UserAlreadyExistsException) {
-                throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
-            } else {
-                throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
-            }
-        }
-    }
-
-    @DELETE
-    @Path("/users/{username}")
-    @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DELETE_USER)
-    @Authenticate(AccessType.DELETE)
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Delete a user", notes = "Delete a user")
-    public SuccessResponse deleteUser(@PathParam("username") String username,
-        @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
-
-        List<String> usersDeleted = new LinkedList<>();
-        String usernameWithComponentType = username + "_" + componentTypeStr;
-
-        try {
-
-            boolean userExist = false;
-            userExist = _pinotHelixResourceManager.hasUser(username, componentTypeStr);
-
-            _pinotHelixResourceManager.deleteUser(usernameWithComponentType);
-            if (userExist) {
-                usersDeleted.add(username);
-            }
-            if (!usersDeleted.isEmpty()) {
-                return new SuccessResponse("User: " + usernameWithComponentType + " has been successfully deleted");
-            }
-        } catch (Exception e) {
-            throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
-        }
-
+    UserConfig userConfig;
+    String usernameWithComponentType = username + "_" + componentTypeStr;
+    try {
+      userConfig = JsonUtils.stringToObject(userConfigString, UserConfig.class);
+      if (passwordChanged) {
+        userConfig.setPassword(BcryptUtils.encrypt(userConfig.getPassword()));
+      }
+      String usernameWithComponentTypeFromUserConfig = userConfig.getUsernameWithComponent();
+      if (!usernameWithComponentType.equals(usernameWithComponentTypeFromUserConfig)) {
         throw new ControllerApplicationException(LOGGER,
-            "User " + usernameWithComponentType + " does not exists", Response.Status.NOT_FOUND);
+            "Request user " + usernameWithComponentType + " does not match " + usernameWithComponentTypeFromUserConfig
+                + " in the Request body", Response.Status.BAD_REQUEST);
+      }
+      if (!_pinotHelixResourceManager.hasUser(username, componentTypeStr)) {
+        throw new ControllerApplicationException(LOGGER,
+            "Request user " + usernameWithComponentType + " does not exist", Response.Status.NOT_FOUND);
+      }
+      _pinotHelixResourceManager.updateUserConfig(userConfig);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
-
-
-    @PUT
-    @Path("/users/{username}")
-    @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.UPDATE_USER)
-    @Authenticate(AccessType.UPDATE)
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Update user config for a user", notes = "Update user config for user")
-    public SuccessResponse updateUserConfig(
-        @PathParam("username") String username,
-        @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr,
-        @QueryParam("passwordChanged") boolean passwordChanged,
-        String userConfigString) {
-
-        UserConfig userConfig;
-        String usernameWithComponentType = username + "_" + componentTypeStr;
-        try {
-            userConfig = JsonUtils.stringToObject(userConfigString, UserConfig.class);
-            if (passwordChanged) {
-                userConfig.setPassword(BcryptUtils.encrypt(userConfig.getPassword()));
-            }
-            String usernameWithComponentTypeFromUserConfig = userConfig.getUsernameWithComponent();
-            if (!usernameWithComponentType.equals(usernameWithComponentTypeFromUserConfig)) {
-                throw new ControllerApplicationException(LOGGER, "Request user " + usernameWithComponentType
-                    + " does not match " + usernameWithComponentTypeFromUserConfig + " in the Request body",
-                    Response.Status.BAD_REQUEST);
-            }
-            if (!_pinotHelixResourceManager.hasUser(username, componentTypeStr)) {
-                throw new ControllerApplicationException(LOGGER,
-                    "Request user " + usernameWithComponentType + " does not exist",
-                    Response.Status.NOT_FOUND);
-            }
-            _pinotHelixResourceManager.updateUserConfig(userConfig);
-        } catch (Exception e) {
-            throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
-        }
-        return new SuccessResponse("User config update for " + usernameWithComponentType);
-    }
+    return new SuccessResponse("User config update for " + usernameWithComponentType);
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -66,6 +66,7 @@ import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.InstanceTypeUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -256,7 +257,9 @@ public class PinotInstanceRestletResource {
   @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.TEXT_PLAIN)
-  @ApiOperation(value = "Enable/disable an instance", notes = "Enable/disable an instance")
+  @ApiOperation(value = "Enable/disable/drain an instance", notes = "Enable/disable/drain an instance. "
+      + "DRAIN state is only applicable to minion instances and retags them from minion_untagged to minion_drained, "
+      + "preventing new task assignments while allowing existing tasks to complete.")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
       @ApiResponse(code = 400, message = "Bad Request"),
@@ -264,9 +267,10 @@ public class PinotInstanceRestletResource {
       @ApiResponse(code = 500, message = "Internal error")
   })
   public SuccessResponse toggleInstanceState(
-      @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000")
+      @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000 "
+          + "| Minion_hostname_9514")
       @PathParam("instanceName") String instanceName,
-      @ApiParam(value = "enable|disable", required = true) @QueryParam("state") String state) {
+      @ApiParam(value = "enable|disable|drain", required = true) @QueryParam("state") String state) {
     if (!_pinotHelixResourceManager.instanceExists(instanceName)) {
       throw new ControllerApplicationException(LOGGER, "Instance '" + instanceName + "' does not exist",
           Response.Status.NOT_FOUND);
@@ -284,6 +288,18 @@ public class PinotInstanceRestletResource {
       if (!response.isSuccessful()) {
         throw new ControllerApplicationException(LOGGER,
             "Failed to disable instance '" + instanceName + "': " + response.getMessage(),
+            Response.Status.INTERNAL_SERVER_ERROR);
+      }
+    } else if (StateType.DRAIN.name().equalsIgnoreCase(state)) {
+      if (!InstanceTypeUtils.isMinion(instanceName)) {
+        throw new ControllerApplicationException(LOGGER,
+            "DRAIN state only applies to minion instances. Instance '" + instanceName + "' is not a minion.",
+            Response.Status.BAD_REQUEST);
+      }
+      PinotResourceManagerResponse response = _pinotHelixResourceManager.drainMinionInstance(instanceName);
+      if (!response.isSuccessful()) {
+        throw new ControllerApplicationException(LOGGER,
+            "Failed to drain minion instance '" + instanceName + "': " + response.getMessage(),
             Response.Status.INTERNAL_SERVER_ERROR);
       }
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMinionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMinionRestletResource.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.apache.pinot.core.auth.Actions;
+import org.apache.pinot.core.auth.Authorize;
+import org.apache.pinot.core.auth.TargetType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
+
+
+/**
+ * REST API for minion-related operations
+ */
+@Api(tags = Constants.MINION_TAG, authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY),
+    @Authorization(value = DATABASE)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = {
+    @ApiKeyAuthDefinition(name = HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
+        key = SWAGGER_AUTHORIZATION_KEY,
+        description = "The format of the key is  ```\"Basic <token>\" or \"Bearer <token>\"```"),
+    @ApiKeyAuthDefinition(name = DATABASE, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = DATABASE,
+        description = "Database context passed through http header. If no context is provided 'default' database "
+            + "context will be considered.")}))
+@Path("/")
+public class PinotMinionRestletResource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotMinionRestletResource.class);
+
+  @Inject
+  PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
+
+  @GET
+  @Path("/minions/status")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get status of all minion instances including task counts and drain state",
+      notes = "Returns status information for all minion instances registered in the cluster")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 400, message = "Bad request - invalid status filter"),
+      @ApiResponse(code = 500, message = "Internal error")
+  })
+  public MinionStatusResponse getMinionStatus(
+      @ApiParam(value = "Filter by status (ONLINE, OFFLINE, or DRAINED)")
+      @QueryParam("status") String status,
+      @ApiParam(value = "Include running task counts for each minion")
+      @QueryParam("includeTaskCounts") @DefaultValue("false") boolean includeTaskCounts) {
+    try {
+      return _pinotHelixTaskResourceManager.getMinionStatus(status, includeTaskCounts);
+    } catch (IllegalArgumentException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, "Failed to get minion status",
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -181,6 +181,7 @@ public class PinotQueryResource {
       String start = requestJson.has("start") ? requestJson.get("start").asText() : null;
       String end = requestJson.has("end") ? requestJson.get("end").asText() : null;
       String step = requestJson.has("step") ? requestJson.get("step").asText() : null;
+      String mode = requestJson.has("mode") ? requestJson.get("mode").asText() : null;
 
       Map<String, String> queryOptions = new HashMap<>();
       if (requestJson.has("queryOptions") && requestJson.get("queryOptions").isObject()) {
@@ -189,7 +190,7 @@ public class PinotQueryResource {
         });
       }
 
-      return executeTimeSeriesQueryCatching(httpHeaders, language, query, start, end, step, queryOptions, true);
+      return executeTimeSeriesQueryCatching(httpHeaders, language, query, start, end, step, queryOptions, mode, true);
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing POST timeseries request", e);
       return constructQueryExceptionResponse(QueryErrorCode.INTERNAL, e.getMessage());
@@ -695,17 +696,18 @@ public class PinotQueryResource {
 
   private StreamingOutput executeTimeSeriesQueryCatching(HttpHeaders httpHeaders, String language, String query,
     String start, String end, String step) {
-    return executeTimeSeriesQueryCatching(httpHeaders, language, query, start, end, step, Map.of(), false);
+    return executeTimeSeriesQueryCatching(httpHeaders, language, query, start, end, step, Map.of(), null, false);
   }
 
   private StreamingOutput executeTimeSeriesQueryCatching(HttpHeaders httpHeaders, String language, String query,
-    String start, String end, String step, Map<String, String> queryOptions, boolean useBrokerCompatibleApi) {
+    String start, String end, String step, Map<String, String> queryOptions, String mode,
+    boolean useBrokerCompatibleApi) {
     try {
       LOGGER.debug("Language: {}, Query: {}, Start: {}, End: {}, Step: {}, UseBrokerAPI: {}",
           language, query, start, end, step, useBrokerCompatibleApi);
       String instanceId = retrieveBrokerForTimeSeriesQuery(query, language, start, end);
-      return sendTimeSeriesRequestToBroker(language, query, start, end, step, queryOptions, instanceId, httpHeaders,
-          useBrokerCompatibleApi);
+      return sendTimeSeriesRequestToBroker(language, query, start, end, step, queryOptions, mode, instanceId,
+          httpHeaders, useBrokerCompatibleApi);
     } catch (QueryException ex) {
       LOGGER.warn("Caught exception while processing timeseries request {}", ex.getMessage());
       return constructQueryExceptionResponse(ex.getErrorCode(), ex.getMessage());
@@ -732,7 +734,7 @@ public class PinotQueryResource {
 
 
   private StreamingOutput sendTimeSeriesRequestToBroker(String language, String query, String start, String end,
-    String step, Map<String, String> queryOptions, String instanceId, HttpHeaders httpHeaders,
+    String step, Map<String, String> queryOptions, String mode, String instanceId, HttpHeaders httpHeaders,
     boolean useBrokerCompatibleApi) {
     InstanceConfig instanceConfig = getInstanceConfig(instanceId);
     String hostName = getHost(instanceConfig);
@@ -758,6 +760,9 @@ public class PinotQueryResource {
       }
       if (step != null && !step.isEmpty()) {
         requestJson.put("step", step);
+      }
+      if (mode != null && !mode.isEmpty()) {
+        requestJson.put("mode", mode);
       }
       if (queryOptions != null && !queryOptions.isEmpty()) {
         ObjectNode queryOptionsNode = JsonUtils.newObjectNode();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -53,10 +53,12 @@ import javax.ws.rs.core.Response;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
 import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
@@ -446,6 +448,26 @@ public class PinotRealtimeTableResource {
       throw new ControllerApplicationException(LOGGER,
           String.format("Failed to get pauseless debug info for table %s. %s", realtimeTableName, e.getMessage()),
           Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/tables/{tableName}/consumerWatermarks")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_IDEAL_STATE)
+  @ApiOperation(value = "Get consumer watermarks for a realtime table",
+      notes = "Returns the next offset to be consumed for each partition group. Only works for realtime tables.")
+  public WatermarkInductionResult getConsumerWatermark(
+      @ApiParam(value = "Name of the realtime table", required = true) @PathParam("tableName") String tableName,
+      @Context HttpHeaders headers) {
+    try {
+      String table = DatabaseUtils.translateTableName(tableName, headers);
+      return _pinotHelixResourceManager.getConsumerWatermarks(table);
+    } catch (TableNotFoundException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.NOT_FOUND, e);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.api.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import io.swagger.annotations.Api;
@@ -36,6 +37,7 @@ import it.unimi.dsi.fastutil.Arrays;
 import it.unimi.dsi.fastutil.Swapper;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -86,7 +88,9 @@ import org.apache.pinot.common.restlet.resources.TableSegmentValidationInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LogicalTableConfigUtils;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessType;
@@ -96,6 +100,7 @@ import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.api.exception.TableAlreadyExistsException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
 import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
@@ -121,9 +126,12 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.controller.ControllerJobType;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.zookeeper.data.Stat;
@@ -279,6 +287,140 @@ public class PinotTableRestletResource {
         throw e;
       } else {
         throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
+    }
+  }
+
+  @POST
+  @Path("/tables/{tableName}/copy")
+  @Authorize(targetType = TargetType.TABLE, action = Actions.Table.CREATE_TABLE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Copy a table's schema and config from another cluster", notes = "Non upsert table only")
+  public CopyTableResponse copyTable(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName, String payload,
+      @ApiParam(value = "Include verbose information in response")
+      @QueryParam("verbose") @DefaultValue("false") boolean verbose,
+      @ApiParam(value = "Dry run mode") @QueryParam("dryRun") @DefaultValue("true") boolean dryRun,
+      @Context HttpHeaders headers) {
+    try {
+      LOGGER.info("[copyTable] received request for table: {}, payload: {}", tableName, payload);
+      tableName = DatabaseUtils.translateTableName(tableName, headers);
+
+      if (_pinotHelixResourceManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(tableName)) != null
+          || _pinotHelixResourceManager.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(tableName)) != null) {
+        throw new TableAlreadyExistsException("Table config for " + tableName
+            + " already exists. If this is unexpected, try deleting the table to remove all metadata associated"
+            + " with it before attempting to recreate.");
+      }
+
+      CopyTablePayload copyTablePayload = JsonUtils.stringToObject(payload, CopyTablePayload.class);
+      String sourceControllerUri = copyTablePayload.getSourceClusterUri();
+      Map<String, String> requestHeaders = copyTablePayload.getHeaders();
+
+      LOGGER.info("[copyTable] Start copying table: {} from source: {}", tableName, sourceControllerUri);
+
+      ControllerRequestURLBuilder urlBuilder = ControllerRequestURLBuilder.baseUrl(sourceControllerUri);
+
+      URI schemaUri = new URI(urlBuilder.forTableSchemaGet(tableName));
+      SimpleHttpResponse schemaResponse = HttpClient.wrapAndThrowHttpException(
+          HttpClient.getInstance().sendGetRequest(schemaUri, requestHeaders));
+      String schemaJson = schemaResponse.getResponse();
+      Schema schema = Schema.fromString(schemaJson);
+
+      URI tableConfigUri = new URI(urlBuilder.forTableGet(tableName));
+      SimpleHttpResponse tableConfigResponse = HttpClient.wrapAndThrowHttpException(
+          HttpClient.getInstance().sendGetRequest(tableConfigUri, requestHeaders));
+      String tableConfigJson = tableConfigResponse.getResponse();
+      LOGGER.info("[copyTable] Fetched table config for table: {}", tableName);
+      JsonNode tableConfigNode = JsonUtils.stringToJsonNode(tableConfigJson);
+
+      URI watermarkUri = new URI(urlBuilder.forConsumerWatermarksGet(tableName));
+      SimpleHttpResponse watermarkResponse = HttpClient.wrapAndThrowHttpException(
+          HttpClient.getInstance().sendGetRequest(watermarkUri, requestHeaders));
+      String watermarkJson = watermarkResponse.getResponse();
+      LOGGER.info("[copyTable] Fetched watermarks for table: {}. Result: {}", tableName, watermarkJson);
+      WatermarkInductionResult watermarkInductionResult =
+          JsonUtils.stringToObject(watermarkJson, WatermarkInductionResult.class);
+
+      boolean hasOffline = tableConfigNode.has(TableType.OFFLINE.name());
+      boolean hasRealtime = tableConfigNode.has(TableType.REALTIME.name());
+      if (hasOffline && !hasRealtime) {
+        throw new IllegalStateException("pure offline table copy not supported yet");
+      }
+
+      ObjectNode realtimeTableConfigNode = (ObjectNode) tableConfigNode.get(TableType.REALTIME.name());
+      tweakRealtimeTableConfig(realtimeTableConfigNode, copyTablePayload);
+      TableConfig realtimeTableConfig = JsonUtils.jsonNodeToObject(realtimeTableConfigNode, TableConfig.class);
+      if (realtimeTableConfig.getUpsertConfig() != null) {
+        throw new IllegalStateException("upsert table copy not supported");
+      }
+      LOGGER.info("[copyTable] Successfully fetched and tweaked table config for table: {}", tableName);
+
+      if (dryRun) {
+        return new CopyTableResponse("success", "Dry run", schema, realtimeTableConfig, watermarkInductionResult);
+      }
+
+      List<Pair<PartitionGroupMetadata, Integer>> partitionGroupInfos = watermarkInductionResult.getWatermarks()
+          .stream()
+          .map(watermark -> Pair.of(
+              new PartitionGroupMetadata(watermark.getPartitionGroupId(), new LongMsgOffset(watermark.getOffset())),
+              watermark.getSequenceNumber()))
+          .collect(Collectors.toList());
+
+      _pinotHelixResourceManager.addSchema(schema, true, false);
+      LOGGER.info("[copyTable] Successfully added schema for table: {}", tableName);
+      // Add the table with designated starting kafka offset and segment sequence number to create consuming segments
+      _pinotHelixResourceManager.addTable(realtimeTableConfig, partitionGroupInfos);
+      LOGGER.info("[copyTable] Successfully added table config: {} with designated high watermark", tableName);
+      CopyTableResponse response = new CopyTableResponse("success", "Table copied successfully", null, null, null);
+      if (hasOffline) {
+        response = new CopyTableResponse("warn", "detect offline too; it will only copy real-time segments",
+            null, null, null);
+      }
+      if (verbose) {
+        response.setSchema(schema);
+        response.setTableConfig(realtimeTableConfig);
+        response.setWatermarkInductionResult(watermarkInductionResult);
+      }
+      return response;
+    } catch (Exception e) {
+      LOGGER.error("[copyTable] Error copying table: {}", tableName, e);
+      throw new ControllerApplicationException(LOGGER, "Error copying table: " + e.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  /**
+   * Helper method to tweak the realtime table config. This method is used to set the broker and server tenants, and
+   * optionally replace the pool tags in the instance assignment config.
+   *
+   * @param realtimeTableConfigNode The JSON object representing the realtime table config.
+   * @param copyTablePayload The payload containing tenant and tag pool replacement information.
+   */
+  @VisibleForTesting
+  static void tweakRealtimeTableConfig(ObjectNode realtimeTableConfigNode, CopyTablePayload copyTablePayload) {
+    String brokerTenant = copyTablePayload.getBrokerTenant();
+    String serverTenant = copyTablePayload.getServerTenant();
+    Map<String, String> tagPoolReplacementMap = copyTablePayload.getTagPoolReplacementMap();
+
+    ObjectNode tenantConfig = (ObjectNode) realtimeTableConfigNode.get("tenants");
+    tenantConfig.put("broker", brokerTenant);
+    tenantConfig.put("server", serverTenant);
+    if (tagPoolReplacementMap == null || tagPoolReplacementMap.isEmpty()) {
+      return;
+    }
+    JsonNode instanceAssignmentConfigMap = realtimeTableConfigNode.get("instanceAssignmentConfigMap");
+    if (instanceAssignmentConfigMap == null) {
+      return;
+    }
+    java.util.Iterator<Map.Entry<String, JsonNode>> iterator = instanceAssignmentConfigMap.fields();
+    while (iterator.hasNext()) {
+      Map.Entry<String, JsonNode> entry = iterator.next();
+      JsonNode instanceAssignmentConfig = entry.getValue();
+      ObjectNode tagPoolConfig = (ObjectNode) instanceAssignmentConfig.get("tagPoolConfig");
+      String srcTag = tagPoolConfig.get("tag").asText();
+      if (tagPoolReplacementMap.containsKey(srcTag)) {
+        tagPoolConfig.put("tag", tagPoolReplacementMap.get(srcTag));
       }
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -315,9 +315,6 @@ public class PinotTableRestletResource {
 
       CopyTablePayload copyTablePayload = JsonUtils.stringToObject(payload, CopyTablePayload.class);
       String sourceControllerUri = copyTablePayload.getSourceClusterUri();
-      if (!sourceControllerUri.startsWith("http://") && !sourceControllerUri.startsWith("https://")) {
-        sourceControllerUri = "http://" + sourceControllerUri;
-      }
       Map<String, String> requestHeaders = copyTablePayload.getHeaders();
 
       LOGGER.info("[copyTable] Start copying table: {} from source: {}", tableName, sourceControllerUri);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -425,6 +425,18 @@ public class PinotTableRestletResource {
     }
   }
 
+  @GET
+  @Path("/tables/copyStatus/{jobId}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TABLE_COPY_STATUS)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get status for a submitted table replication job",
+      notes = "Get status for a submitted table replication job")
+  public JsonNode getForceCommitJobStatus(
+      @ApiParam(value = "job id", required = true) @PathParam("jobId") String id) {
+    return JsonUtils.objectToJsonNode(
+        _pinotHelixResourceManager.getControllerJobZKMetadata(id, ControllerJobTypes.TABLE_REPLICATION));
+  }
+
   @PUT
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/recommender")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -315,6 +315,9 @@ public class PinotTableRestletResource {
 
       CopyTablePayload copyTablePayload = JsonUtils.stringToObject(payload, CopyTablePayload.class);
       String sourceControllerUri = copyTablePayload.getSourceClusterUri();
+      if (!sourceControllerUri.startsWith("http://") && !sourceControllerUri.startsWith("https://")) {
+        sourceControllerUri = "http://" + sourceControllerUri;
+      }
       Map<String, String> requestHeaders = copyTablePayload.getHeaders();
 
       LOGGER.info("[copyTable] Start copying table: {} from source: {}", tableName, sourceControllerUri);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/StateType.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/StateType.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.controller.api.resources;
 
 public enum StateType {
-  ENABLE, DISABLE, DROP
+  ENABLE, DISABLE, DROP, DRAIN
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -172,6 +172,7 @@ import org.apache.pinot.spi.config.user.UserConfig;
 import org.apache.pinot.spi.config.workload.QueryWorkloadConfig;
 import org.apache.pinot.spi.controller.ControllerJobType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
@@ -1574,9 +1575,56 @@ public class PinotHelixResourceManager {
       if (forceTableSchemaUpdate) {
         LOGGER.warn("Force updated schema: {} which is backward incompatible with the existing schema", oldSchema);
       } else {
-        // TODO: Add the reason of the incompatibility
-        throw new SchemaBackwardIncompatibleException("New schema: " + schemaName + " is not backward-compatible with "
-            + "the existing schema");
+        // Build detailed error message with incompatibility reasons
+        StringBuilder errorMsg = new StringBuilder();
+        errorMsg.append("New schema: ").append(schemaName)
+            .append(" is not backward-compatible with the existing schema.");
+        errorMsg.append("\n\nIncompatibility Details:");
+
+        // Check for missing columns
+        Set<String> newSchemaColumns = schema.getColumnNames();
+        List<String> missingColumns = new ArrayList<>();
+        for (String oldColumn : oldSchema.getColumnNames()) {
+          if (!newSchemaColumns.contains(oldColumn)) {
+            missingColumns.add(oldColumn);
+          }
+        }
+
+        if (!missingColumns.isEmpty()) {
+          errorMsg.append("\n- Missing columns (present in old schema but not in new): ").append(missingColumns);
+        }
+
+        // Check for incompatible field specs
+        List<String> incompatibleFields = new ArrayList<>();
+        for (Map.Entry<String, FieldSpec> entry : oldSchema.getFieldSpecMap().entrySet()) {
+          String columnName = entry.getKey();
+          if (newSchemaColumns.contains(columnName)) {
+            FieldSpec oldFieldSpec = entry.getValue();
+            FieldSpec newFieldSpec = schema.getFieldSpecFor(columnName);
+            if (!newFieldSpec.isBackwardCompatibleWith(oldFieldSpec)) {
+              incompatibleFields.add(String.format("%s (old: %s %s, new: %s %s)",
+                  columnName,
+                  oldFieldSpec.getFieldType(),
+                  oldFieldSpec.getDataType(),
+                  newFieldSpec.getFieldType(),
+                  newFieldSpec.getDataType()));
+            }
+          }
+        }
+
+        if (!incompatibleFields.isEmpty()) {
+          errorMsg.append("\n- Incompatible field specifications: ").append(incompatibleFields);
+        }
+
+        // Add suggestions
+        errorMsg.append("\n\nSuggestions to fix:");
+        errorMsg.append("\n1. Ensure all columns from the existing schema are retained in the new schema");
+        errorMsg.append("\n2. Do not change the data type or field type of existing columns");
+        errorMsg.append("\n3. New columns should be added as optional fields with default values");
+        errorMsg.append("\n4. If you must make breaking changes, consider creating a new schema version or use "
+            + "forceTableSchemaUpdate=true (use with caution)");
+
+        throw new SchemaBackwardIncompatibleException(errorMsg.toString());
       }
     }
     ZKMetadataProvider.setSchema(_propertyStore, schema);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
@@ -31,6 +31,8 @@ public class WatermarkInductionResult {
 
   private List<Watermark> _watermarks;
 
+  public List<String> _historicalSegments;
+
   /**
    * The @JsonCreator annotation marks this constructor to be used for deserializing
    * a JSON array back into a WaterMarks object.
@@ -38,8 +40,10 @@ public class WatermarkInductionResult {
    * @param watermarks The list of watermarks.
    */
   @JsonCreator
-  public WatermarkInductionResult(@JsonProperty("watermarks") List<Watermark> watermarks) {
+  public WatermarkInductionResult(@JsonProperty("watermarks") List<Watermark> watermarks,
+      @JsonProperty("historicalSegments") List<String> historicalSegments) {
     _watermarks = watermarks;
+    _historicalSegments = historicalSegments;
   }
 
   /**
@@ -50,6 +54,11 @@ public class WatermarkInductionResult {
   @JsonGetter("watermarks")
   public List<Watermark> getWatermarks() {
     return _watermarks;
+  }
+
+  @JsonGetter("historicalSegments")
+  public List<String> getHistoricalSegments() {
+    return _historicalSegments;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
@@ -31,7 +31,7 @@ public class WatermarkInductionResult {
 
   private List<Watermark> _watermarks;
 
-  public List<String> _historicalSegments;
+  private List<String> _historicalSegments;
 
   /**
    * The @JsonCreator annotation marks this constructor to be used for deserializing

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+
+/**
+ * Represents the result of a watermark induction process, containing a list of watermarks.
+ */
+public class WatermarkInductionResult {
+
+  private List<Watermark> _watermarks;
+
+  /**
+   * The @JsonCreator annotation marks this constructor to be used for deserializing
+   * a JSON array back into a WaterMarks object.
+   *
+   * @param watermarks The list of watermarks.
+   */
+  @JsonCreator
+  public WatermarkInductionResult(@JsonProperty("watermarks") List<Watermark> watermarks) {
+    _watermarks = watermarks;
+  }
+
+  /**
+   * Gets the list of watermarks.
+   *
+   * @return The list of watermarks.
+   */
+  @JsonGetter("watermarks")
+  public List<Watermark> getWatermarks() {
+    return _watermarks;
+  }
+
+  /**
+   * Represents a single watermark with its partitionGroupId, sequence, and offset.
+   */
+  public static class Watermark {
+    private int _partitionGroupId;
+    private int _sequenceNumber;
+    private long _offset;
+
+    /**
+     * The @JsonCreator annotation tells Jackson to use this constructor to create
+     * a WaterMark instance from a JSON object. The @JsonProperty annotations
+     * map the keys in the JSON object to the constructor parameters.
+     *
+     * @param partitionGroupId The ID of the partition group.
+     * @param sequenceNumber The segment sequence number of the consuming segment.
+      * @param offset The first Kafka offset whose corresponding record has not yet sealed in Pinot
+     */
+    @JsonCreator
+    public Watermark(@JsonProperty("partitionGroupId") int partitionGroupId,
+        @JsonProperty("sequenceNumber") int sequenceNumber, @JsonProperty("offset") long offset) {
+      _partitionGroupId = partitionGroupId;
+      _sequenceNumber = sequenceNumber;
+      _offset = offset;
+    }
+
+    /**
+     * Gets the partition group ID.
+     *
+     * @return The partition group ID.
+     */
+    @JsonGetter("partitionGroupId")
+    public int getPartitionGroupId() {
+      return _partitionGroupId;
+    }
+
+    /**
+     * Gets the segment sequence number of the most recent consuming segment.
+     *
+     * @return The segment sequence number.
+     */
+    @JsonGetter("sequenceNumber")
+    public int getSequenceNumber() {
+      return _sequenceNumber;
+    }
+
+    /**
+     * The high-watermark of the Kafka offsets. Any Kafka record with an offset greater than or equal to this
+     * value has not yet been sealed.
+     *
+     * @return The offset.
+     */
+    @JsonGetter("offset")
+    public long getOffset() {
+      return _offset;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/controllerjob/ControllerJobTypes.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/controllerjob/ControllerJobTypes.java
@@ -40,7 +40,8 @@ public enum ControllerJobTypes implements ControllerJobType {
   RELOAD_SEGMENT,
   FORCE_COMMIT,
   TABLE_REBALANCE,
-  TENANT_REBALANCE;
+  TENANT_REBALANCE,
+  TABLE_REPLICATION;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerJobTypes.class);
   private static final EnumMap<ControllerJobTypes, Integer> ZK_NUM_JOBS_LIMIT = new EnumMap<>(ControllerJobTypes.class);
@@ -55,6 +56,7 @@ public enum ControllerJobTypes implements ControllerJobType {
     ZK_NUM_JOBS_LIMIT.put(FORCE_COMMIT, controllerConf.getMaxForceCommitZkJobs());
     ZK_NUM_JOBS_LIMIT.put(TABLE_REBALANCE, controllerConf.getMaxTableRebalanceZkJobs());
     ZK_NUM_JOBS_LIMIT.put(TENANT_REBALANCE, controllerConf.getMaxTenantRebalanceZkJobs());
+    ZK_NUM_JOBS_LIMIT.put(TABLE_REPLICATION, controllerConf.getMaxTableReplicationZkJobs());
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -189,23 +189,172 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   public synchronized Map<String, String> createTask(String taskType, String tableName, @Nullable String taskName,
       Map<String, String> taskConfigs)
       throws Exception {
-    if (taskName == null) {
-      taskName = tableName + "_" + UUID.randomUUID();
-      LOGGER.info("Task name is missing, auto-generate one: {}", taskName);
-    }
-    String minionInstanceTag =
-        taskConfigs.getOrDefault(MINION_INSTANCE_TAG_CONFIG, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
-    _helixTaskResourceManager.ensureTaskQueueExists(taskType);
-    addTaskTypeMetricsUpdaterIfNeeded(taskType);
+    prepTaskQueue(taskType);
     if (!isTaskSchedulable(taskType, List.of(tableName))) {
       return new HashMap<>();
     }
-    String parentTaskName = _helixTaskResourceManager.getParentTaskName(taskType, taskName);
-    TaskState taskState = _helixTaskResourceManager.getTaskState(parentTaskName);
-    if (taskState != null) {
-      throw new TaskAlreadyExistsException(
-          "Task [" + taskName + "] of type [" + taskType + "] is already created. Current state is " + taskState);
+
+    String parentTaskName = getParentTaskName(taskType, tableName, taskName);
+
+    List<String> tableNameWithTypes = getTableNameWithTypes(tableName);
+    LOGGER.info("Generating tasks for {} tables, list: {}", tableNameWithTypes.size(), tableNameWithTypes);
+
+    // Generate each type of tasks
+    PinotTaskGenerator taskGenerator = getTaskGenerator(taskType, tableName);
+    // responseMap holds the table to task name mapping.
+    Map<String, String> responseMap = new HashMap<>();
+    for (String tableNameWithType : tableNameWithTypes) {
+      LOGGER.info("Trying to create tasks of type: {}, table: {}", taskType, tableNameWithType);
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+      if (isExceedingResourceUtilizationLimits(tableNameWithType)) {
+        continue;
+      }
+
+      // Update the task config with the triggeredBy information
+      // This can be used by the generator to appropriately set the subtask configs
+      // Example usage in BaseTaskGenerator.getNumSubTasks()
+      String triggeredBy = CommonConstants.TaskTriggers.ADHOC_TRIGGER.name();
+      taskConfigs.put(MinionConstants.TRIGGERED_BY, triggeredBy);
+
+      DistributedTaskLockManager.TaskLock lock = acquireTaskLock(taskType, tableNameWithType, "ad-hoc");
+
+      try {
+        List<PinotTaskConfig> pinotTaskConfigs = taskGenerator.generateTasks(tableConfig, taskConfigs);
+        if (pinotTaskConfigs.isEmpty()) {
+          LOGGER.warn("No ad-hoc task generated for task type: {}, for table: {}", taskType, tableNameWithType);
+          continue;
+        }
+        pinotTaskConfigs =
+            validatePinotTaskConfigs(taskType, tableNameWithType, taskGenerator, pinotTaskConfigs, triggeredBy);
+        pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
+            .computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> triggeredBy));
+        addDefaultsToTaskConfig(pinotTaskConfigs);
+        LOGGER.info("Submitting ad-hoc task for task type: {} with task configs: {}", taskType, pinotTaskConfigs);
+        String minionInstanceTag =
+            taskConfigs.getOrDefault(MINION_INSTANCE_TAG_CONFIG, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
+        _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
+        responseMap.put(tableNameWithType,
+            submitTasks(parentTaskName, pinotTaskConfigs, taskGenerator, triggeredBy, minionInstanceTag));
+      } finally {
+        if (!responseMap.containsKey(tableNameWithType)) {
+          LOGGER.warn("No task submitted for tableNameWithType: {}", tableNameWithType);
+        }
+        if (lock != null) {
+          _distributedTaskLockManager.releaseLock(lock);
+        }
+      }
     }
+    if (responseMap.isEmpty()) {
+      LOGGER.warn("No task submitted for tableName: {}", tableName);
+    }
+    return responseMap;
+  }
+
+  /**
+   * This method performs the following validations:
+   * <ul>
+   *   <li>Checks if the number of generated tasks exceeds the maximum allowed subtasks per task
+   *       (controlled by {@link MinionConstants#MAX_ALLOWED_SUB_TASKS_KEY} cluster config)</li>
+   *   <li>For user-triggered tasks: If the limit is exceeded, clears all task configs and throws
+   *       a {@link RuntimeException} to notify the user immediately</li>
+   *   <li>For scheduled tasks: If the limit is exceeded, logs a warning and limits the number of
+   *       tasks to the maximum allowed by taking only the first N tasks (where N is the maximum)</li>
+   *   <li>Adds metadata to each task config indicating the maximum number of subtasks that were
+   *       used (via {@link MinionConstants#TABLE_MAX_NUM_TASKS_KEY}) when tasks are limited</li>
+   * </ul>
+   *
+   */
+  protected static List<PinotTaskConfig> validatePinotTaskConfigs(String taskType, String tableNameWithType,
+      PinotTaskGenerator taskGenerator, List<PinotTaskConfig> pinotTaskConfigs, String triggeredBy) {
+    int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
+    if (pinotTaskConfigs.size() > maxNumberOfSubTasks) {
+      String message = "Number of tasks generated for task type: " + taskType + " for table: " + tableNameWithType
+          + " is " + pinotTaskConfigs.size() + ", which is greater than the maximum number of tasks to schedule: "
+          + maxNumberOfSubTasks + ". This is controlled by the cluster config "
+          + MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY + " which is set based on controller's performance.";
+      if (TaskSchedulingContext.isUserTriggeredTask(triggeredBy)) {
+        message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
+        pinotTaskConfigs.clear();
+        // If the task is user-triggered, we throw an exception to notify the user
+        // This is to ensure that the user is aware of the task generation limit
+        throw new RuntimeException(message);
+      }
+      // For scheduled tasks, we log a warning and limit the number of tasks
+      LOGGER.warn(message + "Only the first {} tasks will be scheduled", maxNumberOfSubTasks);
+      pinotTaskConfigs = new ArrayList<>(pinotTaskConfigs.subList(0, maxNumberOfSubTasks));
+      // Provide user visibility to the maximum number of subtasks that were used for the task
+      pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
+          .put(MinionConstants.TABLE_MAX_NUM_TASKS_KEY, String.valueOf(maxNumberOfSubTasks)));
+    }
+    return pinotTaskConfigs;
+  }
+
+  /**
+   * Acquires a distributed lock for the given table to prevent concurrent task generation.
+   * <p>
+   * The lock protects against:
+   * <ul>
+   *   <li>Race conditions with periodic task generation</li>
+   *   <li>Multiple simultaneous ad-hoc requests</li>
+   *   <li>Leadership changes during task generation</li>
+   * </ul>
+   *
+   * @param taskType The type of task being generated
+   * @param tableNameWithType The table name with type for which to acquire the lock
+   * @param flowName The flow name (e.g., "ad-hoc", "scheduled") for logging purposes
+   * @return A {@link DistributedTaskLockManager.TaskLock} if the lock is successfully acquired,
+   *         or {@code null} if distributed locking is disabled (when
+   *         {@code _distributedTaskLockManager} is {@code null})
+   * @throws RuntimeException If distributed locking is enabled but the lock cannot be acquired
+   *                          (typically because another controller is already generating tasks
+   *                          for this table).
+   */
+  protected @Nullable DistributedTaskLockManager.TaskLock acquireTaskLock(String taskType, String tableNameWithType,
+      String flowName) {
+    DistributedTaskLockManager.TaskLock lock = null;
+    if (_distributedTaskLockManager != null) {
+      lock = _distributedTaskLockManager.acquireLock(tableNameWithType);
+      if (lock == null) {
+        String message = "Could not acquire table level distributed lock for " + flowName + " task type: " + taskType
+            + ", table: " + tableNameWithType + ". Another controller is likely generating tasks for this table. "
+            + "Please try again later.";
+        LOGGER.warn(message);
+        throw new RuntimeException(message);
+      }
+      LOGGER.info("Acquired table level distributed lock for {} task type: {} on table: {}", flowName, taskType,
+          tableNameWithType);
+    }
+    return lock;
+  }
+
+  protected boolean isExceedingResourceUtilizationLimits(String tableNameWithType) {
+    try {
+      if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
+          UtilizationChecker.CheckPurpose.TASK_GENERATION) == UtilizationChecker.CheckResult.FAIL) {
+        LOGGER.warn("Resource utilization is above threshold, skipping task creation for table: {}", tableNameWithType);
+        _controllerMetrics.setOrUpdateTableGauge(tableNameWithType,
+            ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
+        return true;
+      }
+      _controllerMetrics.setOrUpdateTableGauge(tableNameWithType,
+          ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 0L);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while checking resource utilization for table: {}", tableNameWithType, e);
+    }
+    return false;
+  }
+
+  protected PinotTaskGenerator getTaskGenerator(String taskType, String tableName) {
+    PinotTaskGenerator taskGenerator = _taskGeneratorRegistry.getTaskGenerator(taskType);
+    if (taskGenerator == null) {
+      throw new UnknownTaskTypeException(
+          "Task type: " + taskType + " is not registered, cannot enable it for table: " + tableName);
+    }
+    return taskGenerator;
+  }
+
+  protected List<String> getTableNameWithTypes(String tableName)
+      throws TableNotFoundException {
     List<String> tableNameWithTypes = new ArrayList<>();
     if (TableNameBuilder.getTableTypeFromTableName(tableName) == null) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
@@ -224,96 +373,26 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     if (tableNameWithTypes.isEmpty()) {
       throw new TableNotFoundException("'tableName' " + tableName + " is not found");
     }
-    LOGGER.info("Generating tasks for {} tables, list: {}", tableNameWithTypes.size(), tableNameWithTypes);
+    return tableNameWithTypes;
+  }
 
-    PinotTaskGenerator taskGenerator = _taskGeneratorRegistry.getTaskGenerator(taskType);
-    // Generate each type of tasks
-    if (taskGenerator == null) {
-      throw new UnknownTaskTypeException(
-          "Task type: " + taskType + " is not registered, cannot enable it for table: " + tableName);
+  protected String getParentTaskName(String taskType, String tableName, String taskName) {
+    if (taskName == null) {
+      taskName = tableName + "_" + UUID.randomUUID();
+      LOGGER.info("Task name is missing, auto-generate one: {}", taskName);
     }
-    // responseMap holds the table to task name mapping.
-    Map<String, String> responseMap = new HashMap<>();
-    for (String tableNameWithType : tableNameWithTypes) {
-      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-      LOGGER.info("Trying to create tasks of type: {}, table: {}", taskType, tableNameWithType);
-      try {
-        if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION) == UtilizationChecker.CheckResult.FAIL) {
-          LOGGER.warn("Resource utilization is above threshold, skipping task creation for table: {}", tableName);
-          _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
-          continue;
-        }
-        _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 0L);
-      } catch (Exception e) {
-        LOGGER.warn("Caught exception while checking resource utilization for table: {}", tableName, e);
-      }
-
-      // Update the task config with the triggeredBy information
-      // This can be used by the generator to appropriately set the subtask configs
-      // Example usage in BaseTaskGenerator.getNumSubTasks()
-      taskConfigs.put(MinionConstants.TRIGGERED_BY, CommonConstants.TaskTriggers.ADHOC_TRIGGER.name());
-
-      // Acquire distributed lock before proceeding with ad-hoc task generation
-      // Need locking to protect against:
-      // 1. Race conditions with periodic task generation
-      // 2. Multiple simultaneous ad-hoc requests
-      // 3. Leadership changes during task generation
-      DistributedTaskLockManager.TaskLock lock = null;
-      if (_distributedTaskLockManager != null) {
-        lock = _distributedTaskLockManager.acquireLock(tableNameWithType);
-        if (lock == null) {
-          String message = String.format("Could not acquire table level distributed lock for ad-hoc task type: %s, "
-                  + "table: %s. Another controller is likely generating tasks for this table. Please try again later.",
-              taskType, tableNameWithType);
-          LOGGER.warn(message);
-          throw new RuntimeException(message);
-        }
-        LOGGER.info("Acquired table level distributed lock for ad-hoc task type: {} on table: {}", taskType,
-            tableNameWithType);
-      }
-
-      try {
-        List<PinotTaskConfig> pinotTaskConfigs = taskGenerator.generateTasks(tableConfig, taskConfigs);
-        if (pinotTaskConfigs.isEmpty()) {
-          LOGGER.warn("No ad-hoc task generated for task type: {}, for table: {}", taskType, tableNameWithType);
-          continue;
-        }
-        int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
-        if (pinotTaskConfigs.size() > maxNumberOfSubTasks) {
-          String message = String.format(
-              "Number of tasks generated for task type: %s for table: %s is %d, which is greater than the "
-                  + "maximum number of tasks to schedule: %d. This is controlled by the cluster config %s which is set "
-                  + "based on controller's performance.", taskType, tableNameWithType, pinotTaskConfigs.size(),
-              maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
-          message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
-          // We throw an exception to notify the user
-          // This is to ensure that the user is aware of the task generation limit
-          throw new RuntimeException(message);
-        }
-        pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
-            .computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> CommonConstants.TaskTriggers.ADHOC_TRIGGER.name()));
-        addDefaultsToTaskConfig(pinotTaskConfigs);
-        LOGGER.info("Submitting ad-hoc task for task type: {} with task configs: {}", taskType, pinotTaskConfigs);
-        _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
-        responseMap.put(tableNameWithType,
-            _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag,
-                taskGenerator.getTaskTimeoutMs(minionInstanceTag),
-                taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
-                taskGenerator.getMaxAttemptsPerTask(minionInstanceTag)));
-      } finally {
-        if (!responseMap.containsKey(tableNameWithType)) {
-          LOGGER.warn("No task submitted for tableNameWithType: {}", tableNameWithType);
-        }
-        if (lock != null) {
-          _distributedTaskLockManager.releaseLock(lock);
-        }
-      }
+    String parentTaskName = _helixTaskResourceManager.getParentTaskName(taskType, taskName);
+    TaskState taskState = _helixTaskResourceManager.getTaskState(parentTaskName);
+    if (taskState != null) {
+      throw new TaskAlreadyExistsException(
+          "Task [" + taskName + "] of type [" + taskType + "] is already created. Current state is " + taskState);
     }
-    if (responseMap.isEmpty()) {
-      LOGGER.warn("No task submitted for tableName: {}", tableName);
-    }
-    return responseMap;
+    return parentTaskName;
+  }
+
+  protected void prepTaskQueue(String taskType) {
+    _helixTaskResourceManager.ensureTaskQueueExists(taskType);
+    addTaskTypeMetricsUpdaterIfNeeded(taskType);
   }
 
   public void forceReleaseLock(String tableNameWithType) {
@@ -741,8 +820,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       List<TableConfig> enabledTableConfigs = entry.getValue();
       PinotTaskGenerator taskGenerator = _taskGeneratorRegistry.getTaskGenerator(taskType);
       if (taskGenerator != null) {
-        _helixTaskResourceManager.ensureTaskQueueExists(taskType);
-        addTaskTypeMetricsUpdaterIfNeeded(taskType);
+        prepTaskQueue(taskType);
 
         // Take the lock for all tables for which to schedule the tasks and pass the list of tables for which getting
         // the lock was successful
@@ -750,21 +828,15 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         // 1. Race conditions with periodic task generation
         // 2. Multiple simultaneous ad-hoc requests
         // 3. Leadership changes during task generation
-        List<String> enabledTables =
-            enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
+        List<String> enabledTables = getTableNames(enabledTableConfigs);
         Map<String, DistributedTaskLockManager.TaskLock> acquiredTaskLocks = new HashMap<>();
         for (String tableName : enabledTables) {
-          DistributedTaskLockManager.TaskLock lock;
-          if (_distributedTaskLockManager != null) {
-            lock = _distributedTaskLockManager.acquireLock(tableName);
-            if (lock == null) {
-              LOGGER.warn("Could not acquire table level distributed lock for scheduled task type: {} on table: {}, "
-                  + "skipping lock acquisition", taskType, tableName);
-              continue;
+          try {
+            DistributedTaskLockManager.TaskLock lock = acquireTaskLock(taskType, tableName, "scheduled");
+            if (lock != null) {
+              acquiredTaskLocks.put(tableName, lock);
             }
-            acquiredTaskLocks.put(tableName, lock);
-            LOGGER.info("Acquired table level distributed lock for scheduled task type: {} on table: {}", taskType,
-                tableName);
+          } catch (RuntimeException ignore) {
           }
         }
 
@@ -783,8 +855,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           }
         }
       } else {
-        List<String> enabledTables =
-            enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
+        List<String> enabledTables = getTableNames(enabledTableConfigs);
         String message = "Task type: " + taskType + " is not registered, cannot enable it for tables: " + enabledTables;
         LOGGER.warn(message);
         TaskSchedulingInfo taskSchedulingInfo = new TaskSchedulingInfo();
@@ -794,6 +865,13 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     }
 
     return tasksScheduled;
+  }
+
+  /**
+   * Extracts table names from a list of table configs.
+   */
+  protected static List<String> getTableNames(List<TableConfig> tableConfigs) {
+    return tableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
   }
 
   @Deprecated(forRemoval = true)
@@ -821,8 +899,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       Map<String, DistributedTaskLockManager.TaskLock> acquiredTaskLocks) {
     TaskSchedulingInfo response = new TaskSchedulingInfo();
     String taskType = taskGenerator.getTaskType();
-    List<String> enabledTables =
-        enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
+    List<String> enabledTables = getTableNames(enabledTableConfigs);
     LOGGER.info("Trying to schedule task type: {}, for tables: {}, isLeader: {}", taskType, enabledTables, isLeader);
     if (!isTaskSchedulable(taskType, enabledTables)) {
       response.addSchedulingError("Unable to start scheduling for task type " + taskType
@@ -833,17 +910,13 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     for (TableConfig tableConfig : enabledTableConfigs) {
       String tableName = tableConfig.getTableName();
       try {
-        if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableName,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION) == UtilizationChecker.CheckResult.FAIL) {
-          String message = String.format("Skipping tasks generation as resource utilization is not within limits for "
-              + "table: %s. Disk utilization for one or more servers hosting this table has exceeded the threshold. "
-              + "Tasks won't be generated until the issue is mitigated.", tableName);
-          LOGGER.warn(message);
+        if (isExceedingResourceUtilizationLimits(tableName)) {
+          String message = "Skipping tasks generation as resource utilization is not within limits for table: "
+              + tableName + ". Disk utilization for one or more servers hosting this table has exceeded the threshold. "
+              + "Tasks won't be generated until the issue is mitigated.";
           response.addGenerationError(message);
-          _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
           continue;
         }
-        _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 0L);
         String minionInstanceTag = minionInstanceTagForTask != null ? minionInstanceTagForTask
             : taskGenerator.getMinionInstanceTag(tableConfig);
         List<PinotTaskConfig> presentTaskConfig =
@@ -859,27 +932,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
 
         if (_distributedTaskLockManager == null || acquiredTaskLocks.containsKey(tableName)) {
           taskGenerator.generateTasks(List.of(tableConfig), presentTaskConfig);
-          int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
-          if (presentTaskConfig.size() > maxNumberOfSubTasks) {
-            String message = String.format(
-                "Number of tasks generated for task type: %s for table: %s is %d, which is greater than the "
-                    + "maximum number of tasks to schedule: %d. This is "
-                    + "controlled by the cluster config %s which is set based on controller's performance.", taskType,
-                tableName, presentTaskConfig.size(), maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
-            if (TaskSchedulingContext.isUserTriggeredTask(triggeredBy)) {
-              message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
-              presentTaskConfig.clear();
-              // If the task is user-triggered, we throw an exception to notify the user
-              // This is to ensure that the user is aware of the task generation limit
-              throw new RuntimeException(message);
-            }
-            // For scheduled tasks, we log a warning and limit the number of tasks
-            LOGGER.warn(message + "Only the first {} tasks will be scheduled", maxNumberOfSubTasks);
-            presentTaskConfig = new ArrayList<>(presentTaskConfig.subList(0, maxNumberOfSubTasks));
-            // Provide user visibility to the maximum number of subtasks that were used for the task
-            presentTaskConfig.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
-                .put(MinionConstants.TABLE_MAX_NUM_TASKS_KEY, String.valueOf(maxNumberOfSubTasks)));
-          }
+          presentTaskConfig =
+              validatePinotTaskConfigs(taskType, tableName, taskGenerator, presentTaskConfig, triggeredBy);
           minionInstanceTagToTaskConfigs.put(minionInstanceTag, presentTaskConfig);
           long successRunTimestamp = System.currentTimeMillis();
           _taskManagerStatusCache.saveTaskGeneratorInfo(tableName, taskType,
@@ -935,14 +989,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           // This might lead to lot of logs, maybe sum it up and move outside the loop
           LOGGER.info("Submitting {} tasks for task type: {} to minionInstance: {} with task configs: {}", numTasks,
               taskType, minionInstanceTag, pinotTaskConfigs);
-          pinotTaskConfigs.forEach(pinotTaskConfig ->
-              pinotTaskConfig.getConfigs().computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> triggeredBy));
-          String submittedTaskName = _helixTaskResourceManager.submitTask(pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(minionInstanceTag),
-              taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
-              taskGenerator.getMaxAttemptsPerTask(minionInstanceTag));
-          submittedTaskNames.add(submittedTaskName);
-          _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
+          submittedTaskNames.add(submitTasks(null, pinotTaskConfigs, taskGenerator, triggeredBy, minionInstanceTag));
         }
       } catch (Exception e) {
         numErrorTasksScheduled++;
@@ -965,6 +1012,23 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       }
     }
     return response.setScheduledTaskNames(submittedTaskNames);
+  }
+
+  protected String submitTasks(@Nullable String parentTaskName, List<PinotTaskConfig> pinotTaskConfigs,
+      PinotTaskGenerator taskGenerator, String triggeredBy, String minionInstanceTag) {
+    pinotTaskConfigs.forEach(pinotTaskConfig ->
+        pinotTaskConfig.getConfigs().computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> triggeredBy));
+    long taskTimeoutMs = taskGenerator.getTaskTimeoutMs(minionInstanceTag);
+    int numConcurrentTasksPerInstance = taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag);
+    int maxAttemptsPerTask = taskGenerator.getMaxAttemptsPerTask(minionInstanceTag);
+    String submittedTaskName = parentTaskName != null
+        ? _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag, taskTimeoutMs,
+            numConcurrentTasksPerInstance, maxAttemptsPerTask)
+        : _helixTaskResourceManager.submitTask(pinotTaskConfigs, minionInstanceTag, taskTimeoutMs,
+            numConcurrentTasksPerInstance, maxAttemptsPerTask);
+    _controllerMetrics.addMeteredTableValue(taskGenerator.getTaskType(), ControllerMeter.NUMBER_TASKS_SUBMITTED,
+        pinotTaskConfigs.size());
+    return submittedTaskName;
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputer.java
@@ -44,7 +44,7 @@ class SizeBasedSegmentFlushThresholdComputer {
   private final Clock _clock;
 
   private long _timeConsumedForLastSegment;
-  private int _rowsConsumedForLastSegment;
+  private int _rowsIndexedForLastSegment;
   private long _sizeForLastSegment;
   private int _rowsThresholdForLastSegment;
   private double _segmentRowsToSizeRatio;
@@ -115,7 +115,7 @@ class SizeBasedSegmentFlushThresholdComputer {
 
     // Store values using the actual rows consumed for threshold calculations
     _timeConsumedForLastSegment = timeConsumed;
-    _rowsConsumedForLastSegment = (int) rowsForCalculation;
+    _rowsIndexedForLastSegment = (int) rowsForCalculation;
     _sizeForLastSegment = sizeForCalculation;
     _rowsThresholdForLastSegment = rowsThreshold;
 
@@ -171,9 +171,9 @@ class SizeBasedSegmentFlushThresholdComputer {
     // .getSizeThresholdToFlushSegment(),
     // we might end up using a lot more memory than required for the segment Using a minor bump strategy, until
     // we add feature to adjust time We will only slightly bump the threshold based on numRowsConsumed
-    if (_rowsConsumedForLastSegment < _rowsThresholdForLastSegment && _sizeForLastSegment < desiredSegmentSizeBytes) {
+    if (_rowsIndexedForLastSegment < _rowsThresholdForLastSegment && _sizeForLastSegment < desiredSegmentSizeBytes) {
       long timeThresholdMs = streamConfig.getFlushThresholdTimeMillis();
-      long rowsConsumed = _rowsConsumedForLastSegment;
+      long rowsConsumed = _rowsIndexedForLastSegment;
       StringBuilder logStringBuilder = new StringBuilder().append("Time threshold reached. ");
       if (timeThresholdMs < _timeConsumedForLastSegment) {
         // The administrator has reduced the time threshold. Adjust the
@@ -195,9 +195,9 @@ class SizeBasedSegmentFlushThresholdComputer {
     double optimalSegmentSizeBytesMax = desiredSegmentSizeBytes * 1.5;
     long targetRows;
     if (_sizeForLastSegment < optimalSegmentSizeBytesMin) {
-      targetRows = (long) (_rowsConsumedForLastSegment * 1.5);
+      targetRows = (long) (_rowsIndexedForLastSegment * 1.5);
     } else if (_sizeForLastSegment > optimalSegmentSizeBytesMax) {
-      targetRows = _rowsConsumedForLastSegment / 2;
+      targetRows = _rowsIndexedForLastSegment / 2;
     } else {
       targetRows = (long) (desiredSegmentSizeBytes * _segmentRowsToSizeRatio);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/NoOpSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/NoOpSegmentCopier.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.Map;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+
+/**
+ * A no-op segment copier for testing purposes.
+ */
+public class NoOpSegmentCopier implements SegmentCopier {
+
+  @Override
+  public void copy(String tableNameWithType, String segmentName, CopyTablePayload copyTablePayload,
+      Map<String, String> segmentZKMetadata) {
+    // No-op
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -147,7 +147,7 @@ public class RealtimeSegmentCopier implements SegmentCopier {
 
   static ClassicHttpRequest getSendSegmentUriRequest(String controllerUriStr, String downloadUri,
       Map<String, String> headers, String tableNameWithoutType) throws URISyntaxException {
-    URI segmentPushURI = new URI(controllerUriStr + "?tableName=" + tableNameWithoutType);
+    URI segmentPushURI = new URI(controllerUriStr + "/v2/segments?tableName=" + tableNameWithoutType);
     ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(segmentPushURI).setVersion(HttpVersion.HTTP_1_1)
         .setHeader(
             FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE, FileUploadDownloadClient.FileUploadType.URI.toString())

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Copies a realtime segment from source to destination.
+ */
+public class RealtimeSegmentCopier implements SegmentCopier {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentCopier.class);
+  private static final String SEGMENT_UPLOAD_ENDPOINT_TEMPLATE = "/segments?tableName=%s";
+
+  private final String _destinationDeepStoreUri;
+  private final HttpClient _httpClient;
+
+  public RealtimeSegmentCopier(ControllerConf controllerConf) {
+    this(controllerConf, HttpClient.getInstance());
+  }
+
+  public RealtimeSegmentCopier(ControllerConf controllerConf, HttpClient httpClient) {
+    _destinationDeepStoreUri = controllerConf.getDataDir();
+    _httpClient = httpClient;
+  }
+
+
+  /**
+   * Copies a segment to the destination cluster.
+   *
+   * This method performs the following steps:
+   * 1. Get the source segment URI from ZK metadata.
+   * 2. Copy the segment from the source deep store to the destination deep store.
+   * 3. Upload the segment to the destination controller.
+   *
+   * @param tableNameWithType Table name with type suffix
+   * @param segmentName Segment name
+   * @param copyTablePayload Payload for copying a table
+   * @param segmentZKMetadata ZK metadata for the segment
+   */
+  @Override
+  public void copy(String tableNameWithType, String segmentName, CopyTablePayload copyTablePayload,
+      Map<String, String> segmentZKMetadata) {
+    if (!tableNameWithType.endsWith("_REALTIME")) {
+      throw new IllegalArgumentException("Table name must end with _REALTIME");
+    }
+    String tableName = tableNameWithType.substring(0, tableNameWithType.lastIndexOf("_REALTIME"));
+    try {
+      // 1. Get the the source segment uri
+      String downloadUrl = segmentZKMetadata.get("segment.download.url");
+      if (downloadUrl == null) {
+        throw new RuntimeException("Download URL not found in segment ZK metadata for segment: " + segmentName);
+      }
+
+      // 2. Copy the segment from the source deep store to the destination deep store
+      URI sourceSegmentUri = new URI(downloadUrl);
+      PinotFS sourcePinotFS = getPinotFS(sourceSegmentUri);
+      String destSegmentUriStr = _destinationDeepStoreUri + "/" + tableName + "/" + segmentName;
+      URI destSegmentUri = new URI(destSegmentUriStr);
+
+      PinotFS destPinotFS = getPinotFS(destSegmentUri);
+
+      // TODO: use local file system as an intermediate store to support different file system
+      if (sourcePinotFS != destPinotFS) {
+        throw new IllegalArgumentException("Copy files across different file system is not supported");
+      }
+
+      if (!destPinotFS.exists(destSegmentUri)) {
+        sourcePinotFS.copy(sourceSegmentUri, destSegmentUri);
+        LOGGER.info("Copied segment {} from {} to {}", segmentName, sourceSegmentUri, destSegmentUri);
+      } else {
+        LOGGER.info("Segment {} already exists at destination {}", segmentName, destSegmentUri);
+      }
+
+      // 3. Upload the segment to the destination controller
+      String payload = "{\"segmentUri\":\"" + destSegmentUriStr + "\"}";
+      URI uri = new URI(copyTablePayload.getDestinationClusterUri() + String.format(SEGMENT_UPLOAD_ENDPOINT_TEMPLATE,
+          tableName));
+      SimpleHttpResponse response =
+          _httpClient.sendJsonPostRequest(uri, payload, copyTablePayload.getDestinationClusterHeaders());
+      LOGGER.info("Uploaded segment {} to destination controller, status: {}", segmentName, response.getStatusCode());
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while copying segment {}", segmentName, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  static String getScheme(URI uri) {
+    if (uri.getScheme() != null) {
+      return uri.getScheme();
+    }
+    return PinotFSFactory.LOCAL_PINOT_FS_SCHEME;
+  }
+
+  PinotFS getPinotFS(URI uri) {
+    String scheme = getScheme(uri);
+    if (!PinotFSFactory.isSchemeSupported(scheme)) {
+      throw new IllegalArgumentException("File scheme " + scheme + " is not supported.");
+    }
+    return PinotFSFactory.create(scheme);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -118,7 +118,7 @@ public class RealtimeSegmentCopier implements SegmentCopier {
           SimpleHttpResponse response = HttpClient.wrapAndThrowHttpException(
               _httpClient.sendRequest(
                   getSendSegmentUriRequest(dstControllerURIStr, destSegmentUriStr,
-                      copyTablePayload.getDestinationClusterHeaders(), tableName),
+                      copyTablePayload.getDestinationClusterHeaders(), tableName, "REALTIME"),
                   HttpClient.DEFAULT_SOCKET_TIMEOUT_MS));
           LOGGER.info("[copyTable] Response for pushing table {} segment uri {} to location {} - {}: {}", tableName,
               destSegmentUriStr, dstControllerURIStr, response.getStatusCode(),
@@ -146,8 +146,9 @@ public class RealtimeSegmentCopier implements SegmentCopier {
   }
 
   static ClassicHttpRequest getSendSegmentUriRequest(String controllerUriStr, String downloadUri,
-      Map<String, String> headers, String tableNameWithoutType) throws URISyntaxException {
-    URI segmentPushURI = new URI(controllerUriStr + "/v2/segments?tableName=" + tableNameWithoutType);
+      Map<String, String> headers, String tableNameWithoutType, String tableType) throws URISyntaxException {
+    URI segmentPushURI = new URI(controllerUriStr + "/v2/segments?tableName=" + tableNameWithoutType + "&tableType="
+        + tableType);
     ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(segmentPushURI).setVersion(HttpVersion.HTTP_1_1)
         .setHeader(
             FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE, FileUploadDownloadClient.FileUploadType.URI.toString())

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/SegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/SegmentCopier.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.Map;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+
+
+/**
+ * An interface to copy a segment to the destination cluster.
+ */
+public interface SegmentCopier {
+
+  /**
+   * Copies a segment to the destination cluster.
+   * @param tableNameWithType Table name with type suffix
+   * @param segmentName Segment name
+   * @param copyTablePayload Payload for copying a table
+   * @param segmentZKMetadata ZK metadata for the segment
+   */
+  void copy(String tableNameWithType, String segmentName, CopyTablePayload copyTablePayload,
+      Map<String, String> segmentZKMetadata);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationObserver.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+public interface TableReplicationObserver {
+
+  enum Trigger {
+    START_TRIGGER,
+    SEGMENT_REPLICATE_COMPLETED_TRIGGER,
+    SEGMENT_REPLICATE_ERRORED_TRIGGER,
+  }
+
+  void onTrigger(Trigger trigger, String segmentName);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStats.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStats.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * Tracks the progress of table replication.
+ */
+public class TableReplicationProgressStats {
+
+  public enum SegmentStatus {
+    COMPLETED,
+    ERROR,
+  }
+
+  private final AtomicInteger _remainingSegments;
+  private final BlockingQueue<String> _segmentsFailToCopy = new LinkedBlockingQueue<>();
+
+  public TableReplicationProgressStats(int segmentSize) {
+    _remainingSegments = new AtomicInteger(segmentSize);
+  }
+
+  /**
+   * Updates the status of a segment and returns the number of remaining segments.
+   * @param segment The segment name.
+   * @param status The status of the segment replication.
+   * @return The number of remaining segments to be replicated.
+   */
+  public int updateSegmentStatus(String segment, SegmentStatus status) {
+    if (status == SegmentStatus.ERROR) {
+      _segmentsFailToCopy.add(segment);
+    }
+    return _remainingSegments.addAndGet(-1);
+  }
+
+  @JsonGetter("remainingSegments")
+  public int getRemainingSegments() {
+    return _remainingSegments.get();
+  }
+
+  @JsonGetter("segmentsFailToCopy")
+  public List<String> getSegmentsFailToCopy() {
+    return new ArrayList<>(_segmentsFailToCopy);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Replicates a table from a source cluster to a destination cluster.
+ */
+public class TableReplicator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableReplicator.class);
+  private static final String SEGMENT_ZK_METADATA_ENDPOINT_TEMPLATE = "/segments/%s/zkmetadata";
+
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final ExecutorService _executorService;
+  private final SegmentCopier _segmentCopier;
+  private final HttpClient _httpClient;
+
+  public TableReplicator(PinotHelixResourceManager pinotHelixResourceManager, ExecutorService executorService,
+      SegmentCopier segmentCopier) {
+    this(pinotHelixResourceManager, executorService, segmentCopier, HttpClient.getInstance());
+  }
+
+  public TableReplicator(PinotHelixResourceManager pinotHelixResourceManager, ExecutorService executorService,
+      SegmentCopier segmentCopier, HttpClient httpClient) {
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _executorService = executorService;
+    _segmentCopier = segmentCopier;
+    _httpClient = httpClient;
+  }
+
+  /**
+   * Replicates the table by copying segments from source to destination.
+   *
+   * This method performs the following steps:
+   * 1. Fetch ZK metadata for all segments of the table from the source cluster.
+   * 2. Register a new controller job in Zookeeper to track the replication progress.
+   * 3. Initialize a {@link ZkBasedTableReplicationObserver} to update the job status in Zookeeper.
+   * 4. Submit tasks to the executor service to copy segments in parallel.
+   * 5. Each task copies a segment and triggers the observer to update the progress.
+   *
+   * @param jobId The job ID.
+   * @param tableNameWithType The table name with type.
+   * @param copyTablePayload The payload containing the source and destination cluster information.
+   * @param res The watermark induction result.
+   * @throws Exception If an error occurs during replication.
+   */
+  public void replicateTable(String jobId, String tableNameWithType, CopyTablePayload copyTablePayload,
+      WatermarkInductionResult res)
+      throws Exception {
+    // TODO: throw IllegalStateException if any previous jobs doesn't expire.
+    // TODO: replication job canceling mechanism
+    URI zkMetadataUri = new URI(copyTablePayload.getSourceClusterUri()
+        + String.format(SEGMENT_ZK_METADATA_ENDPOINT_TEMPLATE, tableNameWithType));
+    SimpleHttpResponse zkMetadataResponse = HttpClient.wrapAndThrowHttpException(
+        _httpClient.sendGetRequest(zkMetadataUri, copyTablePayload.getHeaders()));
+    String zkMetadataJson = zkMetadataResponse.getResponse();
+    Map<String, Map<String, String>> zkMetadataMap =
+        new ObjectMapper().readValue(zkMetadataJson, new TypeReference<Map<String, Map<String, String>>>() {
+        });
+
+    List<String> segments = new ArrayList<>(zkMetadataMap.keySet());
+    long submitTS = System.currentTimeMillis();
+
+    if (!_pinotHelixResourceManager.addNewSegmentCopyXClusterJob(tableNameWithType, jobId, submitTS, segments)) {
+      throw new Exception("Failed to add segments to replicated table");
+    }
+    ZkBasedTableReplicationObserver observer = new ZkBasedTableReplicationObserver(jobId, tableNameWithType,
+        res.getHistoricalSegments(), _pinotHelixResourceManager);
+    observer.onTrigger(TableReplicationObserver.Trigger.START_TRIGGER, null);
+    ConcurrentLinkedQueue<String> q = new ConcurrentLinkedQueue<>(segments);
+    for (int i = 0; i < 4; i++) {
+      _executorService.submit(() -> {
+        while (true) {
+          String segment = q.poll();
+          if (segment == null) {
+            break;
+          }
+          try {
+            Map<String, String> segmentZKMetadata = zkMetadataMap.get(segment);
+            if (segmentZKMetadata == null) {
+              throw new RuntimeException("Segment ZK metadata not found for segment: " + segment);
+            }
+            _segmentCopier.copy(tableNameWithType, segment, copyTablePayload, segmentZKMetadata);
+            observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, segment);
+          } catch (Exception e) {
+            LOGGER.error("Caught exception while replicating table segment", e);
+            observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, segment);
+          }
+        }
+      });
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
+import org.apache.pinot.controller.helix.core.rebalance.RebalanceJobConstants;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Observes the table replication progress and updates the status in Zookeeper.
+ */
+public class ZkBasedTableReplicationObserver implements TableReplicationObserver {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZkBasedTableReplicationObserver.class);
+
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final String _jobId;
+  private final String _tableNameWithType;
+  private final TableReplicationProgressStats _progressStats;
+  private final List<String> _segmentsToCopy;
+
+  public ZkBasedTableReplicationObserver(String jobId, String tableNameWithType, List<String> segmentsToCopy,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    _jobId = jobId;
+    _tableNameWithType = tableNameWithType;
+    _segmentsToCopy = segmentsToCopy;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _progressStats = new TableReplicationProgressStats(segmentsToCopy.size());
+  }
+
+  @Override
+  public void onTrigger(Trigger trigger, String segmentName) {
+    switch (trigger) {
+      // Table
+      case START_TRIGGER:
+        break;
+      case SEGMENT_REPLICATE_COMPLETED_TRIGGER:
+        // Update progress stats and track in ZK every 100 segments
+        int remaining = _progressStats.updateSegmentStatus(segmentName,
+            TableReplicationProgressStats.SegmentStatus.COMPLETED);
+        if (remaining % 100 == 0) {
+          trackStatsInZk();
+        }
+        break;
+      case SEGMENT_REPLICATE_ERRORED_TRIGGER:
+        // Update progress stats and track in ZK immediately on error
+        _progressStats.updateSegmentStatus(segmentName, TableReplicationProgressStats.SegmentStatus.ERROR);
+        trackStatsInZk();
+        break;
+      default:
+    }
+  }
+
+  private void trackStatsInZk() {
+    Map<String, String> jobMetadata = new HashMap<>();
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, _jobId);
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobTypes.TABLE_REPLICATION.name());
+    jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(System.currentTimeMillis()));
+    jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, _tableNameWithType);
+    try {
+      jobMetadata.put(CommonConstants.ControllerJob.SEGMENTS_TO_BE_COPIED,
+          JsonUtils.objectToString(_segmentsToCopy));
+      jobMetadata.put(RebalanceJobConstants.JOB_METADATA_KEY_REBALANCE_PROGRESS_STATS,
+          JsonUtils.objectToString(_progressStats));
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Error serialising replication stats to JSON for persisting to ZK {}", _jobId, e);
+    }
+    _pinotHelixResourceManager.addControllerJobToZK(_jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+  }
+}

--- a/pinot-controller/src/main/resources/app/App.tsx
+++ b/pinot-controller/src/main/resources/app/App.tsx
@@ -126,7 +126,7 @@ export const App = () => {
   const componentRender = (Component, props, role) => {
     return (
       <div className="p-8">
-        <Layout clusterName={clusterName} {...props} role={role}>
+        <Layout clusterName={clusterName} {...props} role={role} authWorkflow={authWorkflow}>
           <Component {...props} />
         </Layout>
       </div>

--- a/pinot-controller/src/main/resources/app/components/Header.tsx
+++ b/pinot-controller/src/main/resources/app/components/Header.tsx
@@ -33,6 +33,51 @@ type Props = {
 };
 
 const useStyles = makeStyles((theme) => ({
+  clusterContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    marginRight: theme.spacing(2),
+  },
+  clusterBox: {
+    textAlign: 'center',
+    margin: '11.5px 0',
+    paddingLeft: theme.spacing(2),
+    borderLeft: '1px solid rgba(255,255,255,0.5)',
+  },
+  linkGroup: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    fontSize: '0.85rem',
+    paddingLeft: theme.spacing(1.5),
+    whiteSpace: 'nowrap',
+    borderLeft: '1px solid rgba(255,255,255,0.5)',
+  },
+  linkColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: theme.spacing(5),
+    minWidth: theme.spacing(9),
+  },
+  linkItem: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(0, 1),
+  },
+  linkItemTop: {
+    borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
+  },
+  link: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    textDecoration: 'none',
+    fontWeight: 700,
+    '&:hover': {
+      color: '#fff',
+      textDecoration: 'underline',
+    },
+  },
   breadcrumbRoot:{
     flexGrow: 1
   },
@@ -102,11 +147,34 @@ const Header = ({ highlightSidebarLink, showHideSideBarHandler, openSidebar, clu
             <TimezoneSelector variant="outlined" size="small" showIcon={false} />
           </Box>
         </Box>
-        <Box textAlign="center" marginY="11.5px" borderLeft="1px solid rgba(255,255,255,0.5)">
-          <Paper className={classes.paper}>
-            <h4>Cluster Name</h4>
-            <h2>{clusterName}</h2>
-          </Paper>
+        <Box className={classes.clusterContainer}>
+          <Box className={classes.clusterBox}>
+            <Paper className={classes.paper}>
+              <h4>Cluster Name</h4>
+              <h2>{clusterName}</h2>
+            </Paper>
+          </Box>
+          <Box className={classes.linkGroup}>
+            <Logo style={{ width: 18, height: 18, fill: '#fff' }} />
+            <Box className={classes.linkColumn}>
+              <a
+                className={`${classes.link} ${classes.linkItem} ${classes.linkItemTop}`}
+                href="https://pinot.apache.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Website
+              </a>
+              <a
+                className={`${classes.link} ${classes.linkItem}`}
+                href="https://docs.pinot.apache.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Docs
+              </a>
+            </Box>
+          </Box>
         </Box>
       </Box>
     </AppBar>

--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -36,7 +36,11 @@ let navigationItems = [
 
 const Layout = (props) => {
   const role = props.role;
-  if(role === 'ADMIN'){
+  if (props.authWorkflow === 'NONE') {
+    navigationItems.push(
+        {id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> }
+    );
+  } else if(role === 'ADMIN'){
     if(navigationItems.length <5){
       navigationItems = [
         ...navigationItems,

--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -28,7 +28,7 @@ import ZookeeperIcon from './SvgIcons/ZookeeperIcon';
 import app_state from '../app_state';
 import AccountCircleOutlinedIcon from '@material-ui/icons/AccountCircleOutlined';
 
-let navigationItems = [
+const BASE_NAVIGATION_ITEMS = [
   { id: 1, name: 'Cluster Manager', link: '/', icon: <ClusterManagerIcon /> },
   { id: 2, name: 'Query Console', link: '/query', icon: <QueryConsoleIcon /> },
   { id: 4, name: 'Swagger REST API', link: 'help', target: '_blank', icon: <SwaggerIcon /> }
@@ -36,21 +36,28 @@ let navigationItems = [
 
 const Layout = (props) => {
   const role = props.role;
-  if (props.authWorkflow === 'NONE') {
-    navigationItems.push(
-        {id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> }
-    );
-  } else if(role === 'ADMIN'){
-    if(navigationItems.length <5){
-      navigationItems = [
-        ...navigationItems,
-        {id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> },
-        {id: 5, name: "User Console", link: '/user', icon: <AccountCircleOutlinedIcon style={{ width: 24, height: 24, verticalAlign: 'sub' }}/>}
-      ]
+  const navigationItems = React.useMemo(() => {
+    // IMPORTANT: do not mutate a module-level array here. Layout can re-render many times,
+    // and mutation would duplicate entries in the sidebar.
+    if (props.authWorkflow === 'NONE') {
+      return [
+        ...BASE_NAVIGATION_ITEMS,
+        { id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> }
+      ];
     }
-  }
+    if (role === 'ADMIN') {
+      return [
+        ...BASE_NAVIGATION_ITEMS,
+        { id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> },
+        { id: 5, name: 'User Console', link: '/user',
+          icon: <AccountCircleOutlinedIcon style={{ width: 24, height: 24, verticalAlign: 'sub' }} /> }
+      ];
+    }
+    return BASE_NAVIGATION_ITEMS;
+  }, [props.authWorkflow, role]);
+
   const hash = `/${window.location.hash.split('/')[1]}`;
-  const routeObj = navigationItems.find((obj)=>{ return obj.link === hash;});
+  const routeObj = navigationItems.find((obj) => obj.link === hash);
 
   const [selectedId, setSelectedId] = React.useState(routeObj?.id || 1);
   const sidebarOpenState = !(localStorage.getItem('pinot_ui:sidebarState') === 'false');
@@ -62,7 +69,7 @@ const Layout = (props) => {
     }
     if (app_state.hideQueryConsoleTab) {
       return navigationItems.filter((navItem) => navItem.link !== '/query');
-  }
+    }
 
     return navigationItems;
   }, [navigationItems, app_state.queryConsoleOnlyView, app_state.hideQueryConsoleTab]);

--- a/pinot-controller/src/main/resources/app/components/Query/TimeseriesQueryPage.tsx
+++ b/pinot-controller/src/main/resources/app/components/Query/TimeseriesQueryPage.tsx
@@ -21,16 +21,15 @@ import React, { useState, useEffect, useCallback } from 'react';
 import {
   Grid,
   FormControl,
-  InputLabel,
   Select,
   MenuItem,
   Typography,
   makeStyles,
   Button,
   Input,
-  FormControlLabel,
   ButtonGroup,
-  Box
+  Box,
+  Checkbox
 } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
@@ -50,6 +49,18 @@ import { ChartSeries, TableData } from 'Models';
 import { DEFAULT_SERIES_LIMIT } from '../../utils/ChartConstants';
 import CustomizedTables from '../Table';
 import PinotMethodUtils from '../../utils/PinotMethodUtils';
+
+// Constants
+const EDITOR_MIN_HEIGHT = 220;
+const EDITOR_DEFAULT_WIDTH_PERCENT = 75;
+const EDITOR_MIN_WIDTH_PERCENT = 30;
+const EDITOR_MAX_WIDTH_PERCENT = 80;
+const CONTROL_INPUT_HEIGHT = 36;
+
+// Helper functions (outside component to avoid recreation)
+const getCurrentTimestamp = () => Math.floor(Date.now() / 1000).toString();
+const getOneMinuteAgoTimestamp = () => Math.floor((Date.now() - 60 * 1000) / 1000).toString();
+const isMac = () => /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 
 interface CodeMirrorEditor {
   getValue: () => string;
@@ -97,6 +108,32 @@ const useStyles = makeStyles((theme) => ({
   checkBox: {
     margin: '20px 0',
   },
+  queryControlsRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'stretch',
+    margin: '20px 0',
+  },
+  queryControlItem: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  queryControlLabel: {
+    fontSize: '0.875rem',
+    color: 'rgba(0, 0, 0, 0.54)',
+    marginBottom: theme.spacing(1),
+    whiteSpace: 'nowrap',
+  },
+  queryControlInput: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  editorRow: {
+    display: 'flex',
+    width: '100%',
+  },
   actionBtns: {
     margin: '20px 0',
     height: 50,
@@ -111,6 +148,35 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: 4,
     marginBottom: '20px',
     paddingBottom: '48px',
+  },
+  queryOptionsPanel: {
+    flex: 1,
+    marginLeft: theme.spacing(1),
+    minWidth: '18%',
+  },
+  controlSelect: {
+    minWidth: 120,
+    height: CONTROL_INPUT_HEIGHT,
+  },
+  controlInputStart: {
+    minWidth: 130,
+  },
+  controlInputEnd: {
+    minWidth: 130,
+  },
+  controlInputTimeout: {
+    minWidth: 80,
+  },
+  controlInputCheckbox: {
+    height: CONTROL_INPUT_HEIGHT,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  controlButton: {
+    height: CONTROL_INPUT_HEIGHT,
+  },
+  queryControlLabelHidden: {
+    visibility: 'hidden',
   },
   sqlError: {
     whiteSpace: 'pre',
@@ -173,10 +239,11 @@ const ViewToggle: React.FC<{
   viewType: 'json' | 'chart';
   onViewChange: (view: 'json' | 'chart') => void;
   isChartDisabled: boolean;
+  isExplainMode: boolean;
   onCopy: () => void;
   copyMsg: boolean;
   classes: ReturnType<typeof useStyles>;
-}> = ({ viewType, onViewChange, isChartDisabled, onCopy, copyMsg, classes }) => (
+}> = ({ viewType, onViewChange, isChartDisabled, isExplainMode, onCopy, copyMsg, classes }) => (
   <Grid container className={classes.actionBtns} alignItems="center" justify="space-between">
     <Grid item>
       <ButtonGroup color="primary" size="small">
@@ -185,7 +252,7 @@ const ViewToggle: React.FC<{
           variant={viewType === 'chart' ? "contained" : "outlined"}
           disabled={isChartDisabled}
         >
-          Chart
+          {isExplainMode ? 'Result' : 'Chart'}
         </Button>
         <Button
           onClick={() => onViewChange('json')}
@@ -234,6 +301,8 @@ interface TimeseriesQueryConfig {
   startTime: string;
   endTime: string;
   timeout: number;
+  queryOptions: string;
+  explainPlan: boolean;
 }
 
 const TimeseriesQueryPage = () => {
@@ -241,15 +310,14 @@ const TimeseriesQueryPage = () => {
   const history = useHistory();
   const location = useLocation();
 
-  const getCurrentTimestamp = () => Math.floor(Date.now() / 1000).toString();
-  const getOneMinuteAgoTimestamp = () => Math.floor((Date.now() - 60 * 1000) / 1000).toString();
-
   const [config, setConfig] = useState<TimeseriesQueryConfig>({
     queryLanguage: 'm3ql',
     query: '',
     startTime: getOneMinuteAgoTimestamp(),
     endTime: getCurrentTimestamp(),
     timeout: 60000,
+    queryOptions: '',
+    explainPlan: false,
   });
 
   const [supportedLanguages, setSupportedLanguages] = useState<Array<string>>([]);
@@ -265,11 +333,18 @@ const TimeseriesQueryPage = () => {
   const [viewType, setViewType] = useState<'json' | 'chart'>('chart');
   const [selectedMetric, setSelectedMetric] = useState<string | null>(null);
   const [seriesLimitInput, setSeriesLimitInput] = useState<string>(DEFAULT_SERIES_LIMIT.toString());
+  const [editorHeight, setEditorHeight] = useState<number>(EDITOR_MIN_HEIGHT);
+  const [editorWidthPercent, setEditorWidthPercent] = useState<number>(EDITOR_DEFAULT_WIDTH_PERCENT);
+  const editorContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const [resultTable, setResultTable] = useState<TableData>({
+    columns: [],
+    records: [],
+  });
   const [queryStats, setQueryStats] = useState<TableData>({
     columns: [],
     records: [],
   });
-
+  const [executedExplainMode, setExecutedExplainMode] = useState<boolean>(false);
 
   // Fetch supported languages from controller configuration
   useEffect(() => {
@@ -299,6 +374,8 @@ const TimeseriesQueryPage = () => {
       startTime: urlParams.get('start') || getOneMinuteAgoTimestamp(),
       endTime: urlParams.get('end') || getCurrentTimestamp(),
       timeout: parseInt(urlParams.get('timeout') || '60000'),
+      queryOptions: urlParams.get('queryOptions') || '',
+      explainPlan: urlParams.get('mode') === 'explain',
     };
 
     setConfig(newConfig);
@@ -326,6 +403,12 @@ const TimeseriesQueryPage = () => {
     if (newConfig.timeout && newConfig.timeout !== 60000) {
       params.set('timeout', newConfig.timeout.toString());
     }
+    if (newConfig.queryOptions && newConfig.queryOptions.trim().length > 0) {
+      params.set('queryOptions', newConfig.queryOptions.trim());
+    }
+    if (newConfig.explainPlan) {
+      params.set('mode', 'explain');
+    }
 
     const newURL = params.toString() ? `?${params.toString()}` : '';
     history.push({
@@ -340,6 +423,10 @@ const TimeseriesQueryPage = () => {
 
   const handleQueryChange = (editor: CodeMirrorEditor, data: CodeMirrorChangeData, value: string) => {
     setConfig(prev => ({ ...prev, query: value }));
+  };
+
+  const handleQueryOptionsChange = (editor: CodeMirrorEditor, data: CodeMirrorChangeData, value: string) => {
+    setConfig(prev => ({ ...prev, queryOptions: value }));
   };
 
   const handleQueryInterfaceKeyDown = (editor: CodeMirrorEditor, event: KeyboardEvent) => {
@@ -363,6 +450,25 @@ const TimeseriesQueryPage = () => {
       return;
     }
 
+    let queryOptionsObject: Record<string, string | number | boolean> = {};
+    if (config.queryOptions.trim().length > 0) {
+      try {
+        const parsedOptions = JSON.parse(config.queryOptions);
+        if (parsedOptions && typeof parsedOptions === 'object' && !Array.isArray(parsedOptions)) {
+          queryOptionsObject = parsedOptions;
+        } else {
+          setError('Query options must be a JSON object');
+          return;
+        }
+      } catch (parseError) {
+        setError('Query options must be valid JSON');
+        return;
+      }
+    }
+    if (config.timeout && queryOptionsObject.timeoutMs === undefined) {
+      queryOptionsObject.timeoutMs = config.timeout;
+    }
+
     updateURL(config);
     setIsLoading(true);
     setError('');
@@ -371,6 +477,7 @@ const TimeseriesQueryPage = () => {
     setChartSeries([]);
     setTotalSeriesCount(0);
     setQueryStats({ columns: [], records: [] });
+    setResultTable({ columns: [], records: [] });
 
     try {
       const requestPayload = {
@@ -380,7 +487,8 @@ const TimeseriesQueryPage = () => {
         end: config.endTime,
         step: '1m',
         trace: false,
-        queryOptions: `timeoutMs=${config.timeout}`
+        queryOptions: queryOptionsObject,
+        ...(config.explainPlan ? { mode: 'explain' } : {}),
       };
 
       // Call the API and process with the shared broker response processor
@@ -391,6 +499,7 @@ const TimeseriesQueryPage = () => {
 
       // Set query stats (already extracted by the utility)
       setQueryStats(results.queryStats || { columns: [], records: [] });
+      setResultTable(results.result || { columns: [], records: [] });
 
       // Handle exceptions/errors
       if (results.exceptions && results.exceptions.length > 0) {
@@ -416,6 +525,9 @@ const TimeseriesQueryPage = () => {
         setChartSeries([]);
         setTotalSeriesCount(0);
       }
+
+      // Set the executed explain mode state after successful query
+      setExecutedExplainMode(config.explainPlan);
     } catch (error) {
       console.error('Error executing timeseries query:', error);
       const errorMessage = error.response?.data?.message || error.message || 'Unknown error occurred';
@@ -448,25 +560,73 @@ const TimeseriesQueryPage = () => {
       )}
 
       <Grid item xs={12} className={classes.rightPanel}>
-        <Resizable
-          defaultSize={{ width: '100%', height: 148 }}
-          minHeight={148}
-          maxWidth={'100%'}
-          maxHeight={'50vh'}
-          enable={{bottom: true}}>
-          <div className={classes.sqlDiv}>
+        <div className={classes.editorRow} ref={editorContainerRef}>
+          <Resizable
+            size={{ width: `${editorWidthPercent}%`, height: editorHeight }}
+            minHeight={EDITOR_MIN_HEIGHT}
+            minWidth={`${EDITOR_MIN_WIDTH_PERCENT}%`}
+            maxWidth={`${EDITOR_MAX_WIDTH_PERCENT}%`}
+            maxHeight={'50vh'}
+            enable={{ bottom: true, right: true, bottomRight: true }}
+            onResize={(event, direction, ref) => {
+              setEditorHeight(ref.offsetHeight);
+              if (editorContainerRef.current && (direction === 'right' || direction === 'bottomRight')) {
+                const containerWidth = editorContainerRef.current.offsetWidth;
+                const newPercent = Math.min(EDITOR_MAX_WIDTH_PERCENT, Math.max(EDITOR_MIN_WIDTH_PERCENT, (ref.offsetWidth / containerWidth) * 100));
+                setEditorWidthPercent(newPercent);
+              }
+            }}
+          >
+            <div className={classes.sqlDiv}>
+              <TableToolbar
+                name="Timeseries Query Editor"
+                showSearchBox={false}
+                showTooltip={true}
+                tooltipText="This editor supports timeseries queries. Enter your M3QL query here."
+              />
+              <CodeMirror
+                value={config.query}
+                onChange={handleQueryChange}
+                options={{
+                  lineNumbers: true,
+                  mode: 'text/plain',
+                  theme: 'default',
+                  lineWrapping: true,
+                  indentWithTabs: true,
+                  smartIndent: true,
+                  readOnly: supportedLanguages.length === 0,
+                }}
+                className={classes.codeMirror}
+                autoCursor={false}
+                onKeyDown={(editor, event) => handleQueryInterfaceKeyDownRef.current(editor, event)}
+              />
+            </div>
+          </Resizable>
+          <div className={`${classes.sqlDiv} ${classes.queryOptionsPanel}`} style={{ height: editorHeight }}>
             <TableToolbar
-              name="Timeseries Query Editor"
+              name="Query Options (JSON)"
               showSearchBox={false}
               showTooltip={true}
-              tooltipText="This editor supports timeseries queries. Enter your M3QL query here."
+              tooltipText={
+                <span>
+                  Enter query options as a JSON map of strings, e.g. {`{"enableNullHandling": "true"}`}. Please find the list of supported query options in the{' '}
+                  <a
+                    href="https://docs.pinot.apache.org/users/user-guide-query/query-options"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: '#90caf9', textDecoration: 'underline' }}
+                  >
+                    documentation
+                  </a>.
+                </span>
+              }
             />
             <CodeMirror
-              value={config.query}
-              onChange={handleQueryChange}
+              value={config.queryOptions}
+              onChange={handleQueryOptionsChange}
               options={{
                 lineNumbers: true,
-                mode: 'text/plain',
+                mode: 'application/json',
                 theme: 'default',
                 lineWrapping: true,
                 indentWithTabs: true,
@@ -475,19 +635,20 @@ const TimeseriesQueryPage = () => {
               }}
               className={classes.codeMirror}
               autoCursor={false}
-              onKeyDown={(editor, event) => handleQueryInterfaceKeyDownRef.current(editor, event)}
             />
           </div>
-        </Resizable>
+        </div>
 
-        <Grid container className={classes.checkBox} spacing={2} alignItems="center" justify="space-between">
-          <Grid item xs={12} sm={6} md={2} className={classes.gridItem}>
-            <FormControl fullWidth={true} className={classes.formControl}>
-              <InputLabel>Query Language</InputLabel>
+        <div className={classes.queryControlsRow}>
+          <div className={classes.queryControlItem}>
+            <Typography className={classes.queryControlLabel}>Query Language</Typography>
+            <div className={classes.queryControlInput}>
               <Select
                 value={config.queryLanguage}
                 onChange={(e) => handleConfigChange('queryLanguage', e.target.value as string)}
                 disabled={languagesLoading || supportedLanguages.length === 0}
+                variant="outlined"
+                className={classes.controlSelect}
               >
                 {supportedLanguages.map((lang) => (
                   <MenuItem key={lang} value={lang}>
@@ -495,89 +656,119 @@ const TimeseriesQueryPage = () => {
                   </MenuItem>
                 ))}
               </Select>
-            </FormControl>
-          </Grid>
+            </div>
+          </div>
 
-          <Grid item xs={12} md={2} className={classes.gridItem}>
-            <FormControl fullWidth={true} className={classes.formControl}>
-              <InputLabel>Start Time (Unix timestamp)</InputLabel>
+          <div className={classes.queryControlItem}>
+            <Typography className={classes.queryControlLabel}>Start Time (Unix)</Typography>
+            <div className={classes.queryControlInput}>
               <Input
                 type="text"
                 value={config.startTime}
                 onChange={(e) => handleConfigChange('startTime', e.target.value as string)}
                 placeholder={getOneMinuteAgoTimestamp()}
                 disabled={supportedLanguages.length === 0}
+                className={classes.controlInputStart}
               />
-            </FormControl>
-          </Grid>
+            </div>
+          </div>
 
-          <Grid item xs={12} md={2} className={classes.gridItem}>
-            <FormControl fullWidth={true} className={classes.formControl}>
-              <InputLabel>End Time (Unix timestamp)</InputLabel>
+          <div className={classes.queryControlItem}>
+            <Typography className={classes.queryControlLabel}>End Time (Unix)</Typography>
+            <div className={classes.queryControlInput}>
               <Input
                 type="text"
                 value={config.endTime}
                 onChange={(e) => handleConfigChange('endTime', e.target.value as string)}
                 placeholder={getCurrentTimestamp()}
                 disabled={supportedLanguages.length === 0}
+                className={classes.controlInputEnd}
               />
-            </FormControl>
-          </Grid>
+            </div>
+          </div>
 
-          <Grid item xs={12} sm={6} md={2} className={classes.gridItem}>
-            <FormControl fullWidth={true} className={classes.formControl}>
-              <InputLabel>Timeout (Milliseconds)</InputLabel>
+          <div className={classes.queryControlItem}>
+            <Typography className={classes.queryControlLabel}>Timeout (ms)</Typography>
+            <div className={classes.queryControlInput}>
               <Input
                 type="text"
                 value={config.timeout}
                 onChange={(e) => handleConfigChange('timeout', parseInt(e.target.value as string) || 60000)}
                 disabled={supportedLanguages.length === 0}
+                className={classes.controlInputTimeout}
               />
-            </FormControl>
-          </Grid>
+            </div>
+          </div>
 
-          <Grid item xs={12} sm={12} md={2} className={classes.gridItem} style={{ display: 'flex', justifyContent: 'center' }}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleExecuteQuery}
-              disabled={isLoading || !config.query.trim() || supportedLanguages.length === 0}
-              endIcon={<span style={{fontSize: '0.8em', lineHeight: 1}}>{navigator.platform.includes('Mac') ? '⌘↵' : 'Ctrl+↵'}</span>}
-            >
-              {isLoading ? 'Running Query...' : 'Run Query'}
-            </Button>
-          </Grid>
-        </Grid>
+          <div className={classes.queryControlItem}>
+            <Typography className={classes.queryControlLabel}>Explain Plan</Typography>
+            <div className={`${classes.queryControlInput} ${classes.controlInputCheckbox}`}>
+              <Checkbox
+                checked={config.explainPlan}
+                onChange={(e) => handleConfigChange('explainPlan', e.target.checked)}
+                color="primary"
+                size="small"
+                disabled={supportedLanguages.length === 0}
+              />
+            </div>
+          </div>
+
+          <div className={classes.queryControlItem}>
+            <Typography className={`${classes.queryControlLabel} ${classes.queryControlLabelHidden}`}>Run</Typography>
+            <div className={classes.queryControlInput}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleExecuteQuery}
+                disabled={isLoading || !config.query.trim() || supportedLanguages.length === 0}
+                endIcon={<span style={{ fontSize: '0.8em', lineHeight: 1 }}>{isMac() ? '⌘↵' : 'Ctrl+↵'}</span>}
+                className={classes.controlButton}
+              >
+                {isLoading ? 'Running...' : 'Run Query'}
+              </Button>
+            </div>
+          </div>
+        </div>
 
         {queryStats.columns.length > 0 && (
-                <Grid item xs style={{ backgroundColor: 'white' }}>
-                  <CustomizedTables
-                    title="Query Response Stats"
-                    data={queryStats}
-                    showSearchBox={true}
-                    inAccordionFormat={true}
-                  />
-                </Grid>
-              )}
+          <Grid item xs style={{ backgroundColor: 'white' }}>
+            <CustomizedTables
+              title="Query Response Stats"
+              data={queryStats}
+              showSearchBox={true}
+              inAccordionFormat={true}
+            />
+          </Grid>
+        )}
 
         {rawOutput && (
           <Grid item xs style={{ backgroundColor: 'white' }}>
-                         <ViewToggle
-               viewType={viewType}
-               onViewChange={setViewType}
-               isChartDisabled={chartSeries.length === 0}
-               onCopy={copyToClipboard}
-               copyMsg={copyMsg}
-               classes={classes}
-             />
+            <ViewToggle
+              viewType={viewType}
+              onViewChange={setViewType}
+              isChartDisabled={executedExplainMode ? false : chartSeries.length === 0}
+              isExplainMode={executedExplainMode}
+              onCopy={copyToClipboard}
+              copyMsg={copyMsg}
+              classes={classes}
+            />
 
-              {error && (
-                <Alert severity="error" className={classes.sqlError}>
-                  {error}
-                </Alert>
-              )}
+            {error && (
+              <Alert severity="error" className={classes.sqlError}>
+                {error}
+              </Alert>
+            )}
 
-                                    {viewType === 'chart' && (
+            {viewType === 'chart' && executedExplainMode && (
+              <CustomizedTables
+                title="Query Result"
+                data={resultTable}
+                showSearchBox={true}
+                inAccordionFormat={true}
+              />
+            )}
+
+            {viewType === 'chart' && !executedExplainMode && (
               <SimpleAccordion
                 headerTitle="Timeseries Chart & Statistics"
                 showSearchBox={false}

--- a/pinot-controller/src/main/resources/app/components/SimpleAccordion.tsx
+++ b/pinot-controller/src/main/resources/app/components/SimpleAccordion.tsx
@@ -68,6 +68,11 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(1),
+      flex: 1,
+      minWidth: 0,
+      '& > div': {
+        width: '100%',
+      },
     },
     additionalControlsContainer: {
       marginLeft: 'auto',

--- a/pinot-controller/src/main/resources/app/components/TableToolbar.tsx
+++ b/pinot-controller/src/main/resources/app/components/TableToolbar.tsx
@@ -32,7 +32,7 @@ type Props = {
   handleSearch?: Function;
   recordCount?: number;
   showTooltip?: boolean;
-  tooltipText?: string;
+  tooltipText?: React.ReactNode;
   additionalControls?: React.ReactNode;
 };
 
@@ -100,7 +100,7 @@ export default function TableToolbar({
         )}
 
         {showTooltip && (
-          <Tooltip title={tooltipText}>
+          <Tooltip title={tooltipText} interactive>
             <HelpOutlineIcon />
           </Tooltip>
         )}

--- a/pinot-controller/src/main/resources/package-lock.json
+++ b/pinot-controller/src/main/resources/package-lock.json
@@ -5850,9 +5850,9 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6477,6 +6477,16 @@
         "eslint": "^8.56.0"
       }
     },
+    "node_modules/eslint-config-airbnb-typescript/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/eslint-config-airbnb-typescript/node_modules/eslint-config-airbnb-base": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
@@ -6494,6 +6504,53 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-typescript/node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-config-airbnb-typescript/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-config-airbnb/node_modules/eslint-config-airbnb-base": {
@@ -18474,7 +18531,8 @@
           "version": "7.21.0-placeholder-for-preset-env.2",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
           "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -19037,7 +19095,8 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -19630,7 +19689,8 @@
     "@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w=="
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "requires": {}
     },
     "@types/resize-observer-browser": {
       "version": "0.1.11",
@@ -19819,7 +19879,8 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
       "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@typescript-eslint/type-utils": {
       "version": "8.39.0",
@@ -20070,19 +20131,22 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -20124,7 +20188,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -20142,7 +20207,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -20177,7 +20243,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -21568,9 +21635,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="
     },
     "dir-glob": {
       "version": "2.2.2",
@@ -22274,6 +22341,16 @@
         "eslint-config-airbnb-base": "^15.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "eslint-config-airbnb-base": {
           "version": "15.0.0",
           "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
@@ -22284,6 +22361,44 @@
             "object.assign": "^4.1.2",
             "object.entries": "^1.1.5",
             "semver": "^6.3.0"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.32.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+          "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@rtsao/scc": "^1.1.0",
+            "array-includes": "^3.1.9",
+            "array.prototype.findlastindex": "^1.2.6",
+            "array.prototype.flat": "^1.3.3",
+            "array.prototype.flatmap": "^1.3.3",
+            "debug": "^3.2.7",
+            "doctrine": "^2.1.0",
+            "eslint-import-resolver-node": "^0.3.9",
+            "eslint-module-utils": "^2.12.1",
+            "hasown": "^2.0.2",
+            "is-core-module": "^2.16.1",
+            "is-glob": "^4.0.3",
+            "minimatch": "^3.1.2",
+            "object.fromentries": "^2.0.8",
+            "object.groupby": "^1.0.3",
+            "object.values": "^1.2.1",
+            "semver": "^6.3.1",
+            "string.prototype.trimend": "^1.0.9",
+            "tsconfig-paths": "^3.15.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -22642,7 +22757,8 @@
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
           "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "eslint-plugin-testing-library": {
           "version": "5.11.1",
@@ -23031,7 +23147,8 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -25133,7 +25250,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
           "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@jsonjoy.com/json-pack": {
           "version": "1.2.0",
@@ -25151,19 +25269,22 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.6.0.tgz",
           "integrity": "sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "thingies": {
           "version": "1.21.0",
           "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
           "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "tree-dump": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
           "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -26491,7 +26612,8 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
           "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "type-fest": {
           "version": "0.20.2",
@@ -27069,7 +27191,8 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
           "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "type-fest": {
           "version": "0.20.2",
@@ -27273,7 +27396,8 @@
     "re-resizable": {
       "version": "6.9.9",
       "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
-      "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA=="
+      "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
+      "requires": {}
     },
     "react": {
       "version": "16.13.1",
@@ -27288,7 +27412,8 @@
     "react-codemirror2": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
+      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
+      "requires": {}
     },
     "react-diff-viewer": {
       "version": "3.1.1",
@@ -27349,7 +27474,8 @@
     "react-hook-form": {
       "version": "6.15.8",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
-      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg=="
+      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",
@@ -28761,7 +28887,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-loader": {
       "version": "9.5.2",
@@ -29308,7 +29435,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
           "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ajv": {
           "version": "8.17.1",
@@ -29794,7 +29922,8 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "wsl-utils": {
       "version": "0.1.0",
@@ -29890,7 +30019,8 @@
     "zustand": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
-      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA=="
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "requires": {}
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -296,6 +296,159 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     return tags;
   }
 
+  @Test
+  public void testDrainMinionInstance()
+      throws Exception {
+    // Create a minion instance with minion_untagged tag
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
+    Instance minionInstance =
+        new Instance("minion1.test.com", 9514, InstanceType.MINION,
+            Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE),
+            null, 0, 0, 0, 0, false);
+    sendPostRequest(createInstanceUrl, minionInstance.toJsonString());
+    String minionInstanceId = "Minion_minion1.test.com_9514";
+
+    // Verify the minion was created with minion_untagged tag
+    checkInstanceInfo(minionInstanceId, "minion1.test.com", 9514, new String[]{Helix.UNTAGGED_MINION_INSTANCE},
+        null, -1, -1, -1, -1, false);
+
+    // Drain the minion instance
+    String drainUrl = _urlBuilder.forInstanceState(minionInstanceId);
+    sendPutRequest(drainUrl + "?state=DRAIN", "");
+
+    // Verify the minion now has minion_drained tag instead of minion_untagged
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest(_urlBuilder.forInstance(minionInstanceId)));
+    assertEquals(response.get("instanceName").asText(), minionInstanceId);
+    JsonNode tags = response.get("tags");
+    assertEquals(tags.size(), 1);
+    assertEquals(tags.get(0).asText(), Helix.DRAINED_MINION_INSTANCE);
+
+    // Cleanup - delete the minion instance
+    sendDeleteRequest(_urlBuilder.forInstance(minionInstanceId));
+  }
+
+  @Test
+  public void testDrainMinionInstanceWithCustomTags()
+      throws Exception {
+    // Create a minion instance with custom tags - should succeed and replace ALL tags
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
+    List<String> tags = Arrays.asList(Helix.UNTAGGED_MINION_INSTANCE, "custom_tag1", "custom_tag2");
+    Instance minionInstance =
+        new Instance("minion2.test.com", 9515, InstanceType.MINION, tags, null, 0, 0, 0, 0, false);
+    sendPostRequest(createInstanceUrl, minionInstance.toJsonString());
+    String minionInstanceId = "Minion_minion2.test.com_9515";
+
+    // Drain the minion instance - should succeed
+    String drainUrl = _urlBuilder.forInstanceState(minionInstanceId);
+    sendPutRequest(drainUrl + "?state=DRAIN", "");
+
+    // Verify ALL tags were replaced with just minion_drained
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest(_urlBuilder.forInstance(minionInstanceId)));
+    JsonNode responseTags = response.get("tags");
+    assertEquals(responseTags.size(), 1);
+    assertEquals(responseTags.get(0).asText(), Helix.DRAINED_MINION_INSTANCE);
+
+    // Cleanup
+    sendDeleteRequest(_urlBuilder.forInstance(minionInstanceId));
+  }
+
+  @Test
+  public void testDrainMinionInstanceWithOnlyCustomTag()
+      throws Exception {
+    // Create a minion instance with only custom tag - should succeed and replace it
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
+    List<String> tags = Arrays.asList("custom_tag");
+    Instance minionInstance =
+        new Instance("minion3.test.com", 9516, InstanceType.MINION, tags, null, 0, 0, 0, 0, false);
+    sendPostRequest(createInstanceUrl, minionInstance.toJsonString());
+    String minionInstanceId = "Minion_minion3.test.com_9516";
+
+    // Drain the minion instance - should succeed
+    String drainUrl = _urlBuilder.forInstanceState(minionInstanceId);
+    sendPutRequest(drainUrl + "?state=DRAIN", "");
+
+    // Verify tag was replaced with minion_drained
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest(_urlBuilder.forInstance(minionInstanceId)));
+    JsonNode responseTags = response.get("tags");
+    assertEquals(responseTags.size(), 1);
+    assertEquals(responseTags.get(0).asText(), Helix.DRAINED_MINION_INSTANCE);
+
+    // Cleanup
+    sendDeleteRequest(_urlBuilder.forInstance(minionInstanceId));
+  }
+
+  @Test
+  public void testDrainMinionInstanceAlreadyDrainedFails()
+      throws Exception {
+    // Create a minion instance that's already drained - should fail to drain again
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
+    List<String> tags = Arrays.asList(Helix.DRAINED_MINION_INSTANCE);
+    Instance minionInstance =
+        new Instance("minion4.test.com", 9517, InstanceType.MINION, tags, null, 0, 0, 0, 0, false);
+    sendPostRequest(createInstanceUrl, minionInstance.toJsonString());
+    String minionInstanceId = "Minion_minion4.test.com_9517";
+
+    // Attempt to drain the already drained minion instance - should fail
+    String drainUrl = _urlBuilder.forInstanceState(minionInstanceId);
+    assertThrows(IOException.class, () -> sendPutRequest(drainUrl + "?state=DRAIN", ""));
+
+    // Cleanup
+    sendDeleteRequest(_urlBuilder.forInstance(minionInstanceId));
+  }
+
+  @Test
+  public void testDrainNonMinionInstanceFails()
+      throws Exception {
+    // Try to drain a broker instance (should fail)
+    String brokerInstanceId = "Broker_localhost_1234";
+    Instance brokerInstance =
+        new Instance("localhost", 1234, InstanceType.BROKER, Collections.singletonList("broker_tag"), null, 0, 0, 0, 0,
+            false);
+    sendPostRequest(_urlBuilder.forInstanceCreate(), brokerInstance.toJsonString());
+
+    // Attempt to drain the broker - should fail with 400 Bad Request
+    String drainUrl = _urlBuilder.forInstanceState(brokerInstanceId);
+    assertThrows(IOException.class, () -> sendPutRequest(drainUrl + "?state=DRAIN", ""));
+
+    // Cleanup
+    sendDeleteRequest(_urlBuilder.forInstance(brokerInstanceId));
+  }
+
+  @Test
+  public void testDrainNonExistentMinionFails()
+      throws Exception {
+    // Try to drain a non-existent minion instance
+    String nonExistentMinionId = "Minion_nonexistent_9999";
+    String drainUrl = _urlBuilder.forInstanceState(nonExistentMinionId);
+
+    // Should fail with 404 Not Found
+    assertThrows(IOException.class, () -> sendPutRequest(drainUrl + "?state=DRAIN", ""));
+  }
+
+  @Test
+  public void testDrainMinionWithEmptyTags()
+      throws Exception {
+    // Create a minion instance with no tags
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
+    Instance minionInstance =
+        new Instance("minion5.test.com", 9518, InstanceType.MINION, null, null, 0, 0, 0, 0, false);
+    sendPostRequest(createInstanceUrl, minionInstance.toJsonString());
+    String minionInstanceId = "Minion_minion5.test.com_9518";
+
+    // Drain the minion instance
+    String drainUrl = _urlBuilder.forInstanceState(minionInstanceId);
+    sendPutRequest(drainUrl + "?state=DRAIN", "");
+
+    // Verify minion_drained tag was added
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest(_urlBuilder.forInstance(minionInstanceId)));
+    JsonNode responseTags = response.get("tags");
+    assertEquals(responseTags.size(), 1);
+    assertEquals(responseTags.get(0).asText(), Helix.DRAINED_MINION_INSTANCE);
+
+    // Cleanup
+    sendDeleteRequest(_urlBuilder.forInstance(minionInstanceId));
+  }
+
   @AfterClass
   public void tearDown()
       throws Exception {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotMinionRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotMinionRestletResourceTest.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.config.instance.Instance;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class PinotMinionRestletResourceTest extends ControllerTest {
+
+    private ControllerRequestURLBuilder _urlBuilder = null;
+
+    @BeforeClass
+    public void setUp()
+        throws Exception {
+      DEFAULT_INSTANCE.setupSharedStateAndValidate();
+      _urlBuilder = DEFAULT_INSTANCE.getControllerRequestURLBuilder();
+    }
+
+  @Test
+  public void testMinionStatusEndpoint()
+      throws Exception {
+    // Create 5 minion instances
+    List<String> minionIds = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      String host = "minion-status-test-" + i + ".example.com";
+      int port = 9514;
+      Instance minionInstance = new Instance(host, port, InstanceType.MINION,
+          Collections.singletonList(CommonConstants.Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+      sendPostRequest(_urlBuilder.forInstanceCreate(), minionInstance.toJsonString());
+      minionIds.add("Minion_" + host + "_" + port);
+    }
+
+    // Test 1: Get all minions (no filter)
+    String allMinionsUrl = _urlBuilder.forMinionStatus(null, false);
+    String allMinionsResponse = sendGetRequest(allMinionsUrl);
+    JsonNode allMinionsJson = JsonUtils.stringToJsonNode(allMinionsResponse);
+
+    assertNotNull(allMinionsJson.get("currentMinionCount"));
+    // Should have at least our 5 minions (may have more from other tests)
+    assertTrue(allMinionsJson.get("currentMinionCount").asInt() >= 5);
+    assertNotNull(allMinionsJson.get("minionStatus"));
+    assertTrue(allMinionsJson.get("minionStatus").isArray());
+
+    // Verify the structure of minion status
+    for (JsonNode minionStatus : allMinionsJson.get("minionStatus")) {
+      assertNotNull(minionStatus.get("instanceId"));
+      assertNotNull(minionStatus.get("host"));
+      assertNotNull(minionStatus.get("port"));
+      assertNotNull(minionStatus.get("runningTaskCount"));
+      assertNotNull(minionStatus.get("status"));
+      assertEquals(minionStatus.get("status").asText(), "ONLINE");
+    }
+
+    // Test 2: Drain 2 minions
+    String minion0 = minionIds.get(0);
+    String minion2 = minionIds.get(2);
+    sendPutRequest(_urlBuilder.forInstanceState(minion0) + "?state=DRAIN", "");
+    sendPutRequest(_urlBuilder.forInstanceState(minion2) + "?state=DRAIN", "");
+
+    // Test 3: Get only DRAINED minions
+    String drainedMinionsUrl = _urlBuilder.forMinionStatus("DRAINED", false);
+    String drainedMinionsResponse = sendGetRequest(drainedMinionsUrl);
+    JsonNode drainedMinionsJson = JsonUtils.stringToJsonNode(drainedMinionsResponse);
+
+    assertTrue(drainedMinionsJson.get("currentMinionCount").asInt() >= 2);
+    for (JsonNode minionStatus : drainedMinionsJson.get("minionStatus")) {
+      assertEquals(minionStatus.get("status").asText(), "DRAINED");
+    }
+
+    // Test 4: Get only ONLINE minions
+    String onlineMinionsUrl = _urlBuilder.forMinionStatus("ONLINE", false);
+    String onlineMinionsResponse = sendGetRequest(onlineMinionsUrl);
+    JsonNode onlineMinionsJson = JsonUtils.stringToJsonNode(onlineMinionsResponse);
+
+    assertTrue(onlineMinionsJson.get("currentMinionCount").asInt() >= 3);
+    for (JsonNode minionStatus : onlineMinionsJson.get("minionStatus")) {
+      assertEquals(minionStatus.get("status").asText(), "ONLINE");
+    }
+
+    // Cleanup
+    for (String minionId : minionIds) {
+      sendDeleteRequest(_urlBuilder.forInstance(minionId));
+    }
+  }
+
+  @Test
+  public void testMinionStatusEndpointCaseInsensitive()
+      throws Exception {
+    // Create a minion and drain it
+    String host = "minion-case-test.example.com";
+    int port = 9514;
+    Instance minionInstance = new Instance(host, port, InstanceType.MINION,
+        Collections.singletonList(CommonConstants.Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    sendPostRequest(_urlBuilder.forInstanceCreate(), minionInstance.toJsonString());
+    String minionId = "Minion_" + host + "_" + port;
+    sendPutRequest(_urlBuilder.forInstanceState(minionId) + "?state=DRAIN", "");
+
+    // Test case-insensitive status filter
+    String upperCaseUrl = _urlBuilder.forMinionStatus("DRAINED", false);
+    String lowerCaseUrl = _urlBuilder.forMinionStatus("drained", false);
+
+    String upperResponse = sendGetRequest(upperCaseUrl);
+    String lowerResponse = sendGetRequest(lowerCaseUrl);
+
+    JsonNode upperJson = JsonUtils.stringToJsonNode(upperResponse);
+    JsonNode lowerJson = JsonUtils.stringToJsonNode(lowerResponse);
+
+    // Both should return the same results
+    assertTrue(upperJson.get("currentMinionCount").asInt() >= 1);
+    assertTrue(lowerJson.get("currentMinionCount").asInt() >= 1);
+
+    // Cleanup
+    sendDeleteRequest(_urlBuilder.forInstance(minionId));
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    DEFAULT_INSTANCE.cleanup();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.InputStream;
+import java.util.Map;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class PinotTableRestletResourceTest {
+
+  @Test
+  public void testTweakRealtimeTableConfig() throws Exception {
+    try (InputStream inputStream = Thread.currentThread().getContextClassLoader()
+        .getResourceAsStream("table/table_config_with_instance_assignment.json")) {
+      ObjectNode tableConfig = (ObjectNode) JsonUtils.inputStreamToJsonNode(inputStream);
+
+      String brokerTenant = "testBroker";
+      String serverTenant = "testServer";
+      CopyTablePayload copyTablePayload = new CopyTablePayload("http://localhost:9000", null, brokerTenant,
+          serverTenant, Map.of("server1_REALTIME", "testServer_REALTIME"));
+      PinotTableRestletResource.tweakRealtimeTableConfig(tableConfig, copyTablePayload);
+
+      assertEquals(tableConfig.get("tenants").get("broker").asText(), brokerTenant);
+      assertEquals(tableConfig.get("tenants").get("server").asText(), serverTenant);
+      assertEquals(tableConfig.path("instanceAssignmentConfigMap").path("CONSUMING").path("tagPoolConfig").path("tag")
+          .asText(), serverTenant + "_REALTIME");
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMinionDrainTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMinionDrainTest.java
@@ -1,0 +1,495 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.config.instance.Instance;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for minion drain functionality in PinotHelixResourceManager
+ */
+public class PinotHelixResourceManagerMinionDrainTest extends ControllerTest {
+  private List<HelixManager> _fakeMinionHelixManagers = new java.util.ArrayList<>();
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+  }
+
+  /**
+   * Creates a fake minion HelixManager that connects to the cluster, creating a LiveInstance entry.
+   * This is needed for enableInstance to work in tests.
+   */
+  private void createFakeMinionLiveInstance(String instanceId)
+      throws Exception {
+    HelixManager helixManager =
+        HelixManagerFactory.getZKHelixManager(getHelixClusterName(),
+            instanceId, org.apache.helix.InstanceType.PARTICIPANT, getZkUrl());
+    helixManager.connect();
+    _fakeMinionHelixManagers.add(helixManager);
+  }
+
+  @Test
+  public void testDrainMinionInstanceBasic() {
+    // Create a minion instance with minion_untagged tag
+    String minionHost = "minion-test-1.example.com";
+    int minionPort = 9514;
+    Instance minionInstance =
+        new Instance(minionHost, minionPort, InstanceType.MINION, Collections.singletonList(
+            Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful(), "Failed to add minion instance");
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Verify initial state has minion_untagged tag
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    assertNotNull(instanceConfig);
+    List<String> initialTags = instanceConfig.getTags();
+    assertEquals(initialTags.size(), 1);
+    assertTrue(initialTags.contains(Helix.UNTAGGED_MINION_INSTANCE));
+
+    // Drain the minion
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful(), "Failed to drain minion: " + drainResponse.getMessage());
+
+    // Verify tags were updated
+    instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> drainedTags = instanceConfig.getTags();
+    assertEquals(drainedTags.size(), 1);
+    assertFalse(drainedTags.contains(Helix.UNTAGGED_MINION_INSTANCE));
+    assertTrue(drainedTags.contains(Helix.DRAINED_MINION_INSTANCE));
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainMinionInstanceWithCustomTags() {
+    // Create a minion with custom tags - should succeed and replace ALL tags
+    String minionHost = "minion-test-2.example.com";
+    int minionPort = 9515;
+    List<String> tags = Arrays.asList(Helix.UNTAGGED_MINION_INSTANCE, "custom_tag_1", "custom_tag_2");
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        tags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Drain the minion - should succeed
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful());
+
+    // Verify ALL tags were replaced with just minion_drained
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> drainedTags = instanceConfig.getTags();
+    assertEquals(drainedTags.size(), 1);
+    assertEquals(drainedTags.get(0), Helix.DRAINED_MINION_INSTANCE);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainMinionInstanceWithOnlyCustomTag() {
+    // Create a minion with only custom tag - should succeed and replace it
+    String minionHost = "minion-test-3.example.com";
+    int minionPort = 9516;
+    List<String> tags = Arrays.asList("custom_tag");
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        tags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Drain the minion - should succeed
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful());
+
+    // Verify tag was replaced with minion_drained
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> drainedTags = instanceConfig.getTags();
+    assertEquals(drainedTags.size(), 1);
+    assertEquals(drainedTags.get(0), Helix.DRAINED_MINION_INSTANCE);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainMinionInstanceAlreadyDrainedFails() {
+    // Create a minion that's already drained - should throw exception
+    String minionHost = "minion-test-4.example.com";
+    int minionPort = 9517;
+    List<String> tags = Arrays.asList(Helix.DRAINED_MINION_INSTANCE);
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        tags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    try {
+      // Attempt to drain the already drained minion - should throw UnsupportedOperationException
+      PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+      assertFalse(drainResponse.isSuccessful(), "Draining an already drained minion should have failed");
+    } finally {
+      // Cleanup
+      _helixResourceManager.dropInstance(minionInstanceId);
+    }
+  }
+
+  @Test
+  public void testDrainMinionWithEmptyTags() {
+    // Create a minion with no tags
+    String minionHost = "minion-test-5.example.com";
+    int minionPort = 9518;
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION, null, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Drain the minion
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful());
+
+    // Verify minion_drained tag was added
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> drainedTags = instanceConfig.getTags();
+    assertEquals(drainedTags.size(), 1);
+    assertTrue(drainedTags.contains(Helix.DRAINED_MINION_INSTANCE));
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainNonExistentMinionFails() {
+    // Try to drain a non-existent minion
+    String nonExistentMinionId = "Minion_nonexistent.example.com_9999";
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(nonExistentMinionId);
+    assertFalse(drainResponse.isSuccessful());
+    assertTrue(drainResponse.getMessage().contains("not found"));
+  }
+
+  @Test
+  public void testDrainMinionPreservesOtherInstanceConfigFields() {
+    // Create a minion with various config fields set
+    String minionHost = "minion-test-6.example.com";
+    int minionPort = 9519;
+    int grpcPort = 8090;
+    int adminPort = 8091;
+    Instance minionInstance =
+        new Instance(minionHost, minionPort, InstanceType.MINION, Collections.singletonList(
+            Helix.UNTAGGED_MINION_INSTANCE), null, grpcPort, adminPort, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Verify initial config
+    InstanceConfig initialConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    assertEquals(initialConfig.getHostName(), minionHost);
+    assertEquals(Integer.parseInt(initialConfig.getPort()), minionPort);
+    assertEquals(initialConfig.getRecord().getSimpleField(Helix.Instance.GRPC_PORT_KEY), String.valueOf(grpcPort));
+    assertEquals(initialConfig.getRecord().getSimpleField(Helix.Instance.ADMIN_PORT_KEY), String.valueOf(adminPort));
+
+    // Drain the minion
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful());
+
+    // Verify other config fields remain unchanged
+    InstanceConfig drainedConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    assertEquals(drainedConfig.getHostName(), minionHost);
+    assertEquals(Integer.parseInt(drainedConfig.getPort()), minionPort);
+    assertEquals(drainedConfig.getRecord().getSimpleField(Helix.Instance.GRPC_PORT_KEY), String.valueOf(grpcPort));
+    assertEquals(drainedConfig.getRecord().getSimpleField(Helix.Instance.ADMIN_PORT_KEY), String.valueOf(adminPort));
+
+    // Verify only tags changed
+    List<String> drainedTags = drainedConfig.getTags();
+    assertEquals(drainedTags.size(), 1);
+    assertTrue(drainedTags.contains(Helix.DRAINED_MINION_INSTANCE));
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testMultipleDrainOperationsOnSameMinion() {
+    // Create a minion
+    String minionHost = "minion-test-7.example.com";
+    int minionPort = 9520;
+    Instance minionInstance =
+        new Instance(minionHost, minionPort, InstanceType.MINION, Collections.singletonList(
+            Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // First drain should succeed
+    PinotResourceManagerResponse firstDrainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(firstDrainResponse.isSuccessful(), "First drain operation failed");
+
+    // Verify state after first drain
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> tags = instanceConfig.getTags();
+    assertEquals(tags.size(), 1);
+    assertTrue(tags.contains(Helix.DRAINED_MINION_INSTANCE));
+    assertFalse(tags.contains(Helix.UNTAGGED_MINION_INSTANCE));
+
+    // Subsequent drain attempts should throw UnsupportedOperationException (already drained)
+    for (int i = 1; i < 3; i++) {
+        PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+        assertFalse(drainResponse.isSuccessful(), "Subsequent drain operation " + (i + 1) + " should have failed");
+    }
+
+    // Verify final state remains unchanged
+    instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    tags = instanceConfig.getTags();
+    assertEquals(tags.size(), 1);
+    assertTrue(tags.contains(Helix.DRAINED_MINION_INSTANCE));
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainMinionInstanceConcurrentSafety()
+      throws InterruptedException {
+    // Create a minion with only standard tag
+    String minionHost = "minion-test-8.example.com";
+    int minionPort = 9521;
+    List<String> tags = Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE);
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION, tags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Drain from multiple threads concurrently
+    Thread[] threads = new Thread[5];
+    final boolean[] results = new boolean[5];
+
+    for (int i = 0; i < 5; i++) {
+      final int index = i;
+      threads[i] = new Thread(() -> {
+        try {
+          PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+          results[index] = drainResponse.isSuccessful();
+        } catch (UnsupportedOperationException e) {
+          // Expected after first drain succeeds (minion will have minion_drained tag)
+          results[index] = false;
+        }
+      });
+      threads[i].start();
+    }
+
+    // Wait for all threads to complete
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // At least one operation should succeed, others may throw exception after first succeeds
+    // (because minion will have minion_drained tag which is considered custom)
+    int successCount = 0;
+    for (int i = 0; i < 5; i++) {
+      if (results[i]) {
+        successCount++;
+      }
+    }
+    assertTrue(successCount >= 1, "At least one concurrent drain operation should succeed");
+
+    // Verify final state - should have minion_drained tag
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> finalTags = instanceConfig.getTags();
+    assertEquals(finalTags.size(), 1);
+    assertTrue(finalTags.contains(Helix.DRAINED_MINION_INSTANCE));
+    assertFalse(finalTags.contains(Helix.UNTAGGED_MINION_INSTANCE));
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainThenEnableRestoresOriginalTags() throws Exception {
+    // Create a minion with minion_untagged tag
+    String minionHost = "minion-test-9.example.com";
+    int minionPort = 9522;
+    List<String> originalTags = Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE);
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        originalTags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Create a fake minion live instance (simulate minion joining) - needed for enableInstance to work
+    createFakeMinionLiveInstance(minionInstanceId);
+
+    // Drain the minion
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful());
+
+    // Verify it's drained
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> drainedTags = instanceConfig.getTags();
+    assertEquals(drainedTags.size(), 1);
+    assertEquals(drainedTags.get(0), Helix.DRAINED_MINION_INSTANCE);
+
+    // Verify pre-drain tags were stored
+    List<String> storedPreDrainTags = instanceConfig.getRecord().getListField(Helix.PREVIOUS_TAGS);
+    assertNotNull(storedPreDrainTags);
+    assertEquals(storedPreDrainTags, originalTags);
+
+    // Enable the minion - should restore original tags
+    PinotResourceManagerResponse enableResponse = _helixResourceManager.enableInstance(minionInstanceId);
+    assertTrue(enableResponse.isSuccessful());
+
+    // Verify tags were restored
+    instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> restoredTags = instanceConfig.getTags();
+    assertEquals(restoredTags.size(), 1);
+    assertEquals(restoredTags.get(0), Helix.UNTAGGED_MINION_INSTANCE);
+
+    // Verify pre-drain tags were cleared
+    List<String> clearedPreDrainTags = instanceConfig.getRecord().getListField(Helix.PREVIOUS_TAGS);
+    assertTrue(clearedPreDrainTags == null || clearedPreDrainTags.isEmpty());
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testDrainThenEnableRestoresCustomTags() throws Exception {
+    // Create a minion with custom tags
+    String minionHost = "minion-test-10.example.com";
+    int minionPort = 9523;
+    List<String> originalTags = Arrays.asList("minion_partition_A", "custom_tag");
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        originalTags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Create a fake minion live instance (simulate minion joining) - needed for enableInstance to work
+    createFakeMinionLiveInstance(minionInstanceId);
+
+    // Drain the minion
+    PinotResourceManagerResponse drainResponse = _helixResourceManager.drainMinionInstance(minionInstanceId);
+    assertTrue(drainResponse.isSuccessful());
+
+    // Verify it's drained
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    assertEquals(instanceConfig.getTags().size(), 1);
+    assertEquals(instanceConfig.getTags().get(0), Helix.DRAINED_MINION_INSTANCE);
+
+    // Enable the minion - should restore custom tags
+    PinotResourceManagerResponse enableResponse = _helixResourceManager.enableInstance(minionInstanceId);
+    assertTrue(enableResponse.isSuccessful());
+
+    // Verify custom tags were restored
+    instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> restoredTags = instanceConfig.getTags();
+    assertEquals(restoredTags.size(), 2);
+    assertTrue(restoredTags.contains("minion_partition_A"));
+    assertTrue(restoredTags.contains("custom_tag"));
+    assertFalse(restoredTags.contains(Helix.DRAINED_MINION_INSTANCE));
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testEnableNonDrainedMinionDoesNotModifyTags() throws Exception {
+    // Create a normal minion
+    String minionHost = "minion-test-11.example.com";
+    int minionPort = 9524;
+    List<String> originalTags = Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE);
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        originalTags, null, 0, 0, 0, 0, false);
+
+    PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+    assertTrue(addResponse.isSuccessful());
+
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    // Create a fake minion live instance (simulate minion joining) - needed for enableInstance to work
+    createFakeMinionLiveInstance(minionInstanceId);
+
+    // Enable the minion (not drained) - tags should remain unchanged
+    PinotResourceManagerResponse enableResponse = _helixResourceManager.enableInstance(minionInstanceId);
+    assertTrue(enableResponse.isSuccessful());
+
+    // Verify tags were not modified
+    InstanceConfig instanceConfig = _helixResourceManager.getHelixInstanceConfig(minionInstanceId);
+    List<String> tags = instanceConfig.getTags();
+    assertEquals(tags.size(), 1);
+    assertEquals(tags.get(0), Helix.UNTAGGED_MINION_INSTANCE);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    // Disconnect fake minion managers
+    for (HelixManager manager : _fakeMinionHelixManagers) {
+      if (manager != null && manager.isConnected()) {
+        manager.disconnect();
+      }
+    }
+    _fakeMinionHelixManagers.clear();
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMinionStatusTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMinionStatusTest.java
@@ -1,0 +1,812 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskPartitionState;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.task.WorkflowContext;
+import org.apache.pinot.controller.api.resources.MinionStatusResponse;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.apache.pinot.spi.config.instance.Instance;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for minion status query functionality in PinotHelixTaskResourceManager
+ */
+public class PinotHelixResourceManagerMinionStatusTest extends ControllerTest {
+
+  private PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+    _pinotHelixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
+  }
+
+  @AfterMethod
+  public void cleanupAfterTest() {
+    // Clean up all minion instances after each test to ensure test isolation
+    try {
+      for (String instanceId : _helixResourceManager.getAllInstances()) {
+        if (instanceId.startsWith("Minion_")) {
+          try {
+            _helixResourceManager.dropInstance(instanceId);
+          } catch (Exception e) {
+            // Ignore errors during cleanup
+          }
+        }
+      }
+    } catch (Exception e) {
+      // Ignore errors getting all instances
+    }
+  }
+
+  /**
+   * Helper method to create a mock TaskDriver with workflows and jobs containing tasks assigned to minions
+   * @param taskAssignments Map of minion instance ID to number of RUNNING tasks
+   * @return Mocked TaskDriver
+   */
+  private TaskDriver createMockTaskDriverWithRunningTasks(Map<String, Integer> taskAssignments) {
+    TaskDriver mockTaskDriver = mock(TaskDriver.class);
+
+    // Create a mock workflows - getWorkflows() returns a Map<String, WorkflowConfig>
+    Map<String, WorkflowConfig> workflows = new HashMap<>();
+    workflows.put("TestWorkflow1", mock(WorkflowConfig.class));
+    when(mockTaskDriver.getWorkflows()).thenReturn(workflows);
+
+    // Create workflow context with jobs
+    WorkflowContext workflowContext = mock(WorkflowContext.class);
+    when(mockTaskDriver.getWorkflowContext("TestWorkflow1")).thenReturn(workflowContext);
+
+    Map<String, TaskState> jobStates = new HashMap<>();
+    jobStates.put("TestJob1", TaskState.IN_PROGRESS);
+    when(workflowContext.getJobStates()).thenReturn(jobStates);
+
+    // Create job context with tasks assigned to minions
+    JobContext jobContext = mock(JobContext.class);
+    when(mockTaskDriver.getJobContext("TestJob1")).thenReturn(jobContext);
+
+    Set<Integer> partitions = new HashSet<>();
+    int partitionId = 0;
+    for (Map.Entry<String, Integer> entry : taskAssignments.entrySet()) {
+      String minionId = entry.getKey();
+      int taskCount = entry.getValue();
+      for (int i = 0; i < taskCount; i++) {
+        partitions.add(partitionId);
+        when(jobContext.getPartitionState(partitionId)).thenReturn(TaskPartitionState.RUNNING);
+        when(jobContext.getAssignedParticipant(partitionId)).thenReturn(minionId);
+        partitionId++;
+      }
+    }
+    when(jobContext.getPartitionSet()).thenReturn(partitions);
+
+    return mockTaskDriver;
+  }
+
+  @Test
+  public void testGetMinionStatusWithNoMinions() {
+    // Test with no minions registered - no tasks should be running
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(new HashMap<>());
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+    assertNotNull(response);
+    assertEquals(response.getCurrentMinionCount(), 0);
+    assertNotNull(response.getMinionStatus());
+    assertTrue(response.getMinionStatus().isEmpty());
+  }
+
+  @Test
+  public void testGetMinionStatusWithOnlineMinions() {
+    // Create 3 online minions
+    for (int i = 0; i < 3; i++) {
+      String minionHost = "minion-test-" + i + ".example.com";
+      int minionPort = 9514;
+      Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+          Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+      PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+      assertTrue(addResponse.isSuccessful(), "Failed to add minion instance");
+    }
+
+    // Create a mock TaskDriver with running tasks: minion-0 has 2 tasks, minion-1 has 1 task, minion-2 has 0 tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put("Minion_minion-test-0.example.com_9514", 2);
+    taskAssignments.put("Minion_minion-test-1.example.com_9514", 1);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get all minions
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+    assertNotNull(response);
+    assertEquals(response.getCurrentMinionCount(), 3);
+    assertEquals(response.getMinionStatus().size(), 3);
+
+    // Verify all are ONLINE and check task counts
+    for (MinionStatusResponse.MinionStatus status : response.getMinionStatus()) {
+      assertEquals(status.getStatus(), "ONLINE");
+      assertNotNull(status.getInstanceId());
+      assertNotNull(status.getHost());
+      assertTrue(status.getPort() > 0);
+
+      // Verify task counts match expected values
+      if (status.getInstanceId().equals("Minion_minion-test-0.example.com_9514")) {
+        assertEquals(status.getRunningTaskCount(), 2);
+      } else if (status.getInstanceId().equals("Minion_minion-test-1.example.com_9514")) {
+        assertEquals(status.getRunningTaskCount(), 1);
+      } else {
+        assertEquals(status.getRunningTaskCount(), 0);
+      }
+    }
+
+    // Cleanup
+    for (int i = 0; i < 3; i++) {
+      String minionInstanceId = "Minion_minion-test-" + i + ".example.com_" + (9514);
+      _helixResourceManager.dropInstance(minionInstanceId);
+    }
+  }
+
+  @Test
+  public void testGetMinionStatusWithDrainedMinions() {
+    // Create 5 minions
+    for (int i = 0; i < 5; i++) {
+      String minionHost = "minion-drain-test-" + i + ".example.com";
+      int minionPort = 9514;
+      Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+          Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+      PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+      assertTrue(addResponse.isSuccessful());
+    }
+
+    // Drain minions 1 and 3
+    String minion1 = "Minion_minion-drain-test-1.example.com_9514";
+    String minion3 = "Minion_minion-drain-test-3.example.com_9514";
+    _helixResourceManager.drainMinionInstance(minion1);
+    _helixResourceManager.drainMinionInstance(minion3);
+
+    // Create a mock TaskDriver with running tasks: drained minions can still have running tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put("Minion_minion-drain-test-0.example.com_9514", 3);
+    taskAssignments.put(minion1, 1); // Drained but still has 1 running task
+    taskAssignments.put("Minion_minion-drain-test-2.example.com_9514", 2);
+    taskAssignments.put(minion3, 2); // Drained but still has 2 running tasks
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get all minions
+    MinionStatusResponse allResponse = taskResourceManager.getMinionStatus(null, true);
+    assertEquals(allResponse.getCurrentMinionCount(), 5);
+    assertEquals(allResponse.getMinionStatus().size(), 5);
+
+    // Count online vs drained
+    long onlineCount = allResponse.getMinionStatus().stream()
+        .filter(m -> "ONLINE".equals(m.getStatus()))
+        .count();
+    long drainedCount = allResponse.getMinionStatus().stream()
+        .filter(m -> "DRAINED".equals(m.getStatus()))
+        .count();
+    assertEquals(onlineCount, 3);
+    assertEquals(drainedCount, 2);
+
+    // Get only ONLINE minions
+    MinionStatusResponse onlineResponse = taskResourceManager.getMinionStatus("ONLINE", true);
+    assertEquals(onlineResponse.getCurrentMinionCount(), 3);
+    assertEquals(onlineResponse.getMinionStatus().size(), 3);
+    for (MinionStatusResponse.MinionStatus status : onlineResponse.getMinionStatus()) {
+      assertEquals(status.getStatus(), "ONLINE");
+    }
+
+    // Get only DRAINED minions
+    MinionStatusResponse drainedResponse = taskResourceManager.getMinionStatus("DRAINED", true);
+    assertEquals(drainedResponse.getCurrentMinionCount(), 2);
+    assertEquals(drainedResponse.getMinionStatus().size(), 2);
+    for (MinionStatusResponse.MinionStatus status : drainedResponse.getMinionStatus()) {
+      assertEquals(status.getStatus(), "DRAINED");
+      assertTrue(status.getInstanceId().equals(minion1) || status.getInstanceId().equals(minion3));
+      // Verify drained minions can still have running tasks
+      if (status.getInstanceId().equals(minion1)) {
+        assertEquals(status.getRunningTaskCount(), 1);
+      } else if (status.getInstanceId().equals(minion3)) {
+        assertEquals(status.getRunningTaskCount(), 2);
+      }
+    }
+
+    // Cleanup
+    for (int i = 0; i < 5; i++) {
+      String minionInstanceId = "Minion_minion-drain-test-" + i + ".example.com_" + 9514;
+      _helixResourceManager.dropInstance(minionInstanceId);
+    }
+  }
+
+  @Test
+  public void testGetMinionStatusWithFilter() {
+    // Create 6 minions, drain 3 of them
+    for (int i = 0; i < 6; i++) {
+      String minionHost = "minion-filter-" + i + ".example.com";
+      int minionPort = 9514;
+      Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+          Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+      PinotResourceManagerResponse addResponse = _helixResourceManager.addInstance(minionInstance, false);
+      assertTrue(addResponse.isSuccessful());
+    }
+
+    // Drain minions 0, 2, 4
+    for (int i = 0; i < 6; i += 2) {
+      String minionInstanceId = "Minion_minion-filter-" + i + ".example.com_" + (9514);
+      _helixResourceManager.drainMinionInstance(minionInstanceId);
+    }
+
+    // Create a mock TaskDriver with running tasks: drained minions have tasks, online minions have tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put("Minion_minion-filter-0.example.com_9514", 2); // Drained
+    taskAssignments.put("Minion_minion-filter-1.example.com_9514", 3); // Online
+    taskAssignments.put("Minion_minion-filter-2.example.com_9514", 1); // Drained
+    taskAssignments.put("Minion_minion-filter-3.example.com_9514", 2); // Online
+    taskAssignments.put("Minion_minion-filter-4.example.com_9514", 1); // Drained
+    taskAssignments.put("Minion_minion-filter-5.example.com_9514", 1); // Online
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get drained minions
+    MinionStatusResponse response = taskResourceManager.getMinionStatus("DRAINED", true);
+    assertEquals(response.getCurrentMinionCount(), 3);
+    assertEquals(response.getMinionStatus().size(), 3);
+    for (MinionStatusResponse.MinionStatus status : response.getMinionStatus()) {
+      assertEquals(status.getStatus(), "DRAINED");
+    }
+
+    // Get online minions
+    MinionStatusResponse onlineResponse = taskResourceManager.getMinionStatus("ONLINE", true);
+    assertEquals(onlineResponse.getCurrentMinionCount(), 3);
+    assertEquals(onlineResponse.getMinionStatus().size(), 3);
+    for (MinionStatusResponse.MinionStatus status : onlineResponse.getMinionStatus()) {
+      assertEquals(status.getStatus(), "ONLINE");
+    }
+
+    // Cleanup
+    for (int i = 0; i < 6; i++) {
+      String minionInstanceId = "Minion_minion-filter-" + i + ".example.com_" + (9514);
+      _helixResourceManager.dropInstance(minionInstanceId);
+    }
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetMinionStatusWithInvalidFilter() {
+    // Create a minion
+    String minionHost = "minion-invalid-filter.example.com";
+    int minionPort = 9514;
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    _helixResourceManager.addInstance(minionInstance, false);
+
+    // Create a mock TaskDriver with running tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put("Minion_" + minionHost + "_" + minionPort, 1);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    try {
+      // Try with invalid status filter - should throw IllegalArgumentException
+      taskResourceManager.getMinionStatus("INVALID_STATUS", true);
+    } finally {
+      // Cleanup
+      String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+      _helixResourceManager.dropInstance(minionInstanceId);
+    }
+  }
+
+  @Test
+  public void testGetMinionStatusCaseInsensitiveFilter() {
+    // Create 2 minions, drain one
+    String minionHost1 = "minion-case-test-1.example.com";
+    String minionHost2 = "minion-case-test-2.example.com";
+    int minionPort = 9514;
+
+    Instance minion1 = new Instance(minionHost1, minionPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    Instance minion2 = new Instance(minionHost2, minionPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    _helixResourceManager.addInstance(minion1, false);
+    _helixResourceManager.addInstance(minion2, false);
+
+    String minion1Id = "Minion_" + minionHost1 + "_" + minionPort;
+    String minion2Id = "Minion_" + minionHost2 + "_" + minionPort;
+    _helixResourceManager.drainMinionInstance(minion1Id);
+
+    // Create a mock TaskDriver with running tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(minion1Id, 2); // Drained minion with 2 tasks
+    taskAssignments.put(minion2Id, 3); // Online minion with 3 tasks
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Test case-insensitive filters
+    MinionStatusResponse responseUpperCase = taskResourceManager.getMinionStatus("DRAINED", true);
+    MinionStatusResponse responseLowerCase = taskResourceManager.getMinionStatus("drained", true);
+    MinionStatusResponse responseMixedCase = taskResourceManager.getMinionStatus("Drained", true);
+
+    assertEquals(responseUpperCase.getCurrentMinionCount(), 1);
+    assertEquals(responseLowerCase.getCurrentMinionCount(), 1);
+    assertEquals(responseMixedCase.getCurrentMinionCount(), 1);
+
+    // Verify task counts in all responses
+    assertEquals(responseUpperCase.getMinionStatus().get(0).getRunningTaskCount(), 2);
+    assertEquals(responseLowerCase.getMinionStatus().get(0).getRunningTaskCount(), 2);
+    assertEquals(responseMixedCase.getMinionStatus().get(0).getRunningTaskCount(), 2);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minion1Id);
+    _helixResourceManager.dropInstance(minion2Id);
+  }
+
+  @Test
+  public void testGetMinionStatusOnlyReturnsMinions() {
+    // Create different instance types
+    String brokerHost = "broker-test.example.com";
+    String serverHost = "server-test.example.com";
+    String minionHost = "minion-type-test.example.com";
+
+    Instance brokerInstance = new Instance(brokerHost, 8099, InstanceType.BROKER,
+        Collections.singletonList("DefaultTenant_BROKER"), null, 0, 0, 0, 0, false);
+    Instance serverInstance = new Instance(serverHost, 8098, InstanceType.SERVER,
+        Collections.singletonList("DefaultTenant_OFFLINE"), null, 0, 0, 0, 0, false);
+    Instance minionInstance = new Instance(minionHost, 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    _helixResourceManager.addInstance(brokerInstance, false);
+    _helixResourceManager.addInstance(serverInstance, false);
+    _helixResourceManager.addInstance(minionInstance, false);
+
+    // Create a mock TaskDriver with running tasks - only for minion (broker and server won't have task counts)
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put("Minion_" + minionHost + "_9514", 5);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get minion status - should only return the minion instance
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+    assertEquals(response.getCurrentMinionCount(), 1);
+    assertEquals(response.getMinionStatus().size(), 1);
+    assertEquals(response.getMinionStatus().get(0).getHost(), minionHost);
+    assertEquals(response.getMinionStatus().get(0).getRunningTaskCount(), 5);
+
+    // Cleanup
+    _helixResourceManager.dropInstance("Broker_" + brokerHost + "_8099");
+    _helixResourceManager.dropInstance("Server_" + serverHost + "_8098");
+    _helixResourceManager.dropInstance("Minion_" + minionHost + "_9514");
+  }
+
+  @Test
+  public void testGetMinionStatusReturnsCorrectPortAndHost() {
+    // Create minion with specific host and port
+    String expectedHost = "specific-minion-host.example.com";
+    int expectedPort = 9514;
+
+    Instance minionInstance = new Instance(expectedHost, expectedPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    _helixResourceManager.addInstance(minionInstance, false);
+
+    // Create a mock TaskDriver with running tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put("Minion_" + expectedHost + "_" + expectedPort, 4);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get status and verify host/port
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+    assertEquals(response.getCurrentMinionCount(), 1);
+
+    MinionStatusResponse.MinionStatus status = response.getMinionStatus().get(0);
+    assertEquals(status.getHost(), expectedHost);
+    assertEquals(status.getPort(), expectedPort);
+    assertEquals(status.getInstanceId(), "Minion_" + expectedHost + "_" + expectedPort);
+    assertEquals(status.getRunningTaskCount(), 4);
+
+    // Cleanup
+    _helixResourceManager.dropInstance("Minion_" + expectedHost + "_" + expectedPort);
+  }
+
+  @Test
+  public void testGetMinionStatusWithRunningTasks() {
+    // Create 3 minions
+    String minion1Id = "Minion_minion-running-1.example.com_9514";
+    String minion2Id = "Minion_minion-running-2.example.com_9514";
+    String minion3Id = "Minion_minion-running-3.example.com_9514";
+
+    Instance minion1 = new Instance("minion-running-1.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    Instance minion2 = new Instance("minion-running-2.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    Instance minion3 = new Instance("minion-running-3.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    _helixResourceManager.addInstance(minion1, false);
+    _helixResourceManager.addInstance(minion2, false);
+    _helixResourceManager.addInstance(minion3, false);
+
+    // Create a mock TaskDriver with running tasks: minion1 has 3 tasks, minion2 has 1 task, minion3 has 0 tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(minion1Id, 3);
+    taskAssignments.put(minion2Id, 1);
+    // minion3 not in map = 0 running tasks
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Call getMinionStatus on the task resource manager
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+
+    assertNotNull(response);
+    assertEquals(response.getCurrentMinionCount(), 3);
+    assertEquals(response.getMinionStatus().size(), 3);
+
+    // Verify running task counts for each minion
+    for (MinionStatusResponse.MinionStatus status : response.getMinionStatus()) {
+      if (status.getInstanceId().equals(minion1Id)) {
+        assertEquals(status.getRunningTaskCount(), 3);
+      } else if (status.getInstanceId().equals(minion2Id)) {
+        assertEquals(status.getRunningTaskCount(), 1);
+      } else if (status.getInstanceId().equals(minion3Id)) {
+        assertEquals(status.getRunningTaskCount(), 0);
+      }
+    }
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minion1Id);
+    _helixResourceManager.dropInstance(minion2Id);
+    _helixResourceManager.dropInstance(minion3Id);
+  }
+
+  @Test
+  public void testGetMinionStatusWithRunningTasksAndInitTasks() {
+    // This test verifies that getMinionStatus correctly reports running task counts
+    // including both RUNNING and INIT states (tasks assigned but not yet started)
+
+    // Create 2 minions
+    String minion1Id = "Minion_minion-init-test-1.example.com_9514";
+    String minion2Id = "Minion_minion-init-test-2.example.com_9514";
+
+    Instance minion1 = new Instance("minion-init-test-1.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    Instance minion2 = new Instance("minion-init-test-2.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    _helixResourceManager.addInstance(minion1, false);
+    _helixResourceManager.addInstance(minion2, false);
+
+    // Create a mock TaskDriver with running tasks
+    // Simulate: minion1 has 3 RUNNING tasks, minion2 has 1 RUNNING task
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(minion1Id, 3); // 3 RUNNING tasks
+    taskAssignments.put(minion2Id, 1); // 1 RUNNING task
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Call getMinionStatus
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+
+    assertNotNull(response);
+    assertEquals(response.getCurrentMinionCount(), 2);
+
+    // Verify that the running task counts include both RUNNING and INIT tasks
+    Map<String, Integer> resultCounts = new HashMap<>();
+    for (MinionStatusResponse.MinionStatus status : response.getMinionStatus()) {
+      resultCounts.put(status.getInstanceId(), status.getRunningTaskCount());
+    }
+
+    assertEquals(resultCounts.get(minion1Id).intValue(), 3);
+    assertEquals(resultCounts.get(minion2Id).intValue(), 1);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minion1Id);
+    _helixResourceManager.dropInstance(minion2Id);
+  }
+
+  @Test
+  public void testGetMinionStatusWithDrainedMinionAndRunningTasks() {
+    // Test that drained minions can still show running task counts
+    // (tasks that were assigned before draining)
+
+    String minionId = "Minion_minion-drained-running.example.com_9514";
+    Instance minion = new Instance("minion-drained-running.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    _helixResourceManager.addInstance(minion, false);
+
+    // Drain the minion
+    _helixResourceManager.drainMinionInstance(minionId);
+
+    // Create a mock TaskDriver with running tasks
+    // Even though drained, minion might still have running tasks that were assigned before draining
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(minionId, 2);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get all minions
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+    assertEquals(response.getCurrentMinionCount(), 1);
+
+    MinionStatusResponse.MinionStatus status = response.getMinionStatus().get(0);
+    assertEquals(status.getInstanceId(), minionId);
+    assertEquals(status.getStatus(), "DRAINED");
+    assertEquals(status.getRunningTaskCount(), 2); // Should still show running tasks
+
+    // Get only DRAINED minions
+    MinionStatusResponse drainedResponse = taskResourceManager.getMinionStatus("DRAINED", true);
+    assertEquals(drainedResponse.getCurrentMinionCount(), 1);
+    assertEquals(drainedResponse.getMinionStatus().get(0).getRunningTaskCount(), 2);
+
+    // Get only ONLINE minions
+    MinionStatusResponse onlineResponse = taskResourceManager.getMinionStatus("ONLINE", true);
+    assertEquals(onlineResponse.getCurrentMinionCount(), 0);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionId);
+  }
+
+  @Test
+  public void testGetMinionStatusRunningTaskCountException() {
+    // Test that getMinionStatus handles exceptions from getRunningTaskCountsPerMinion gracefully
+
+    String minionId = "Minion_minion-exception-test.example.com_9514";
+    Instance minion = new Instance("minion-exception-test.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    _helixResourceManager.addInstance(minion, false);
+
+    // Create a mock TaskDriver that throws an exception when accessing workflows
+    TaskDriver mockTaskDriver = mock(TaskDriver.class);
+    Mockito.doThrow(new RuntimeException("Simulated task driver failure"))
+        .when(mockTaskDriver).getWorkflows();
+
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // getMinionStatus should still work, just with 0 running task counts
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, true);
+
+    assertNotNull(response);
+    assertEquals(response.getCurrentMinionCount(), 1);
+    assertEquals(response.getMinionStatus().get(0).getRunningTaskCount(), 0);
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionId);
+  }
+
+  @Test
+  public void testGetMinionStatusWithOfflineMinions() {
+    // Test OFFLINE status (Helix disabled minions)
+    // Create 4 minions: 2 ONLINE, 1 OFFLINE, 1 DRAINED
+    String onlineMinion1 = "Minion_minion-offline-test-0.example.com_9514";
+    String offlineMinion = "Minion_minion-offline-test-1.example.com_9514";
+    String onlineMinion2 = "Minion_minion-offline-test-2.example.com_9514";
+    String drainedMinion = "Minion_minion-offline-test-3.example.com_9514";
+
+    for (int i = 0; i < 4; i++) {
+      Instance minion = new Instance("minion-offline-test-" + i + ".example.com", 9514, InstanceType.MINION,
+          Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+      _helixResourceManager.addInstance(minion, false);
+    }
+
+    // Disable one minion in Helix (OFFLINE)
+    _helixResourceManager.disableInstance(offlineMinion);
+
+    // Drain one minion (DRAINED)
+    _helixResourceManager.drainMinionInstance(drainedMinion);
+
+    // Create a mock TaskDriver with running tasks
+    // Note: OFFLINE minions cannot have running tasks since they are disabled in Helix
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(onlineMinion1, 2);
+    taskAssignments.put(onlineMinion2, 3);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Get all minions
+    MinionStatusResponse allResponse = taskResourceManager.getMinionStatus(null, true);
+    assertEquals(allResponse.getCurrentMinionCount(), 4);
+    assertEquals(allResponse.getMinionStatus().size(), 4);
+
+    // Count statuses
+    Map<String, Long> statusCounts = allResponse.getMinionStatus().stream()
+        .collect(Collectors.groupingBy(MinionStatusResponse.MinionStatus::getStatus, Collectors.counting()));
+    assertEquals(statusCounts.get("ONLINE").longValue(), 2);
+    assertEquals(statusCounts.get("OFFLINE").longValue(), 1);
+    assertEquals(statusCounts.get("DRAINED").longValue(), 1);
+
+    // Get only OFFLINE minions
+    MinionStatusResponse offlineResponse = taskResourceManager.getMinionStatus("OFFLINE", true);
+    assertEquals(offlineResponse.getCurrentMinionCount(), 1);
+    assertEquals(offlineResponse.getMinionStatus().size(), 1);
+    assertEquals(offlineResponse.getMinionStatus().get(0).getInstanceId(), offlineMinion);
+    assertEquals(offlineResponse.getMinionStatus().get(0).getStatus(), "OFFLINE");
+    assertEquals(offlineResponse.getMinionStatus().get(0).getRunningTaskCount(), 0);
+
+    // Cleanup
+    for (int i = 0; i < 4; i++) {
+      _helixResourceManager.dropInstance("Minion_minion-offline-test-" + i + ".example.com_9514");
+    }
+  }
+
+  @Test
+  public void testGetMinionStatusWithoutTaskCounts() {
+    // Test that includeTaskCounts=false doesn't query task counts (all should be 0)
+    String minion1Id = "Minion_minion-no-tasks-1.example.com_9514";
+    String minion2Id = "Minion_minion-no-tasks-2.example.com_9514";
+
+    Instance minion1 = new Instance("minion-no-tasks-1.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    Instance minion2 = new Instance("minion-no-tasks-2.example.com", 9514, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+
+    _helixResourceManager.addInstance(minion1, false);
+    _helixResourceManager.addInstance(minion2, false);
+
+    // Create a mock TaskDriver with running tasks
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(minion1Id, 5);
+    taskAssignments.put(minion2Id, 3);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Call with includeTaskCounts=false - all task counts should be 0
+    MinionStatusResponse response = taskResourceManager.getMinionStatus(null, false);
+
+    assertEquals(response.getCurrentMinionCount(), 2);
+    assertEquals(response.getMinionStatus().size(), 2);
+
+    // Verify all task counts are 0 (not queried)
+    for (MinionStatusResponse.MinionStatus status : response.getMinionStatus()) {
+      assertEquals(status.getRunningTaskCount(), 0);
+    }
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minion1Id);
+    _helixResourceManager.dropInstance(minion2Id);
+  }
+
+  @Test
+  public void testGetMinionStatusMixedStates() {
+    // Test with a mix of ONLINE, OFFLINE, and DRAINED minions
+    String onlineMinion = "Minion_minion-mixed-0.example.com_9514";
+    String offlineMinion = "Minion_minion-mixed-1.example.com_9514";
+    String drainedMinion = "Minion_minion-mixed-2.example.com_9514";
+    String onlineMinion2 = "Minion_minion-mixed-3.example.com_9514";
+
+    for (int i = 0; i < 4; i++) {
+      Instance minion = new Instance("minion-mixed-" + i + ".example.com", 9514, InstanceType.MINION,
+          Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+      _helixResourceManager.addInstance(minion, false);
+    }
+
+    // Set different states
+    _helixResourceManager.disableInstance(offlineMinion); // OFFLINE
+    _helixResourceManager.drainMinionInstance(drainedMinion); // DRAINED
+
+    // OFFLINE minions cannot have running tasks since they are disabled in Helix
+    Map<String, Integer> taskAssignments = new HashMap<>();
+    taskAssignments.put(onlineMinion, 1);
+    taskAssignments.put(drainedMinion, 3);
+    taskAssignments.put(onlineMinion2, 4);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(taskAssignments);
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    // Test filtering by each status
+    MinionStatusResponse onlineResponse = taskResourceManager.getMinionStatus("ONLINE", true);
+    assertEquals(onlineResponse.getCurrentMinionCount(), 2);
+    for (MinionStatusResponse.MinionStatus status : onlineResponse.getMinionStatus()) {
+      assertEquals(status.getStatus(), "ONLINE");
+      assertTrue(status.getRunningTaskCount() > 0);
+    }
+
+    MinionStatusResponse offlineResponse = taskResourceManager.getMinionStatus("OFFLINE", true);
+    assertEquals(offlineResponse.getCurrentMinionCount(), 1);
+    assertEquals(offlineResponse.getMinionStatus().get(0).getStatus(), "OFFLINE");
+    assertEquals(offlineResponse.getMinionStatus().get(0).getInstanceId(), offlineMinion);
+    assertEquals(offlineResponse.getMinionStatus().get(0).getRunningTaskCount(), 0);
+
+    MinionStatusResponse drainedResponse = taskResourceManager.getMinionStatus("DRAINED", true);
+    assertEquals(drainedResponse.getCurrentMinionCount(), 1);
+    assertEquals(drainedResponse.getMinionStatus().get(0).getStatus(), "DRAINED");
+    assertEquals(drainedResponse.getMinionStatus().get(0).getInstanceId(), drainedMinion);
+
+    // Cleanup
+    for (int i = 0; i < 4; i++) {
+      _helixResourceManager.dropInstance("Minion_minion-mixed-" + i + ".example.com_9514");
+    }
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetMinionStatusWithInvalidOfflineFilter() {
+    // Test that invalid status filter throws exception (test with various invalid values)
+    String minionHost = "minion-invalid-offline.example.com";
+    int minionPort = 9514;
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    _helixResourceManager.addInstance(minionInstance, false);
+
+    TaskDriver mockTaskDriver = createMockTaskDriverWithRunningTasks(new HashMap<>());
+    PinotHelixTaskResourceManager taskResourceManager = new PinotHelixTaskResourceManager(
+        _helixResourceManager, mockTaskDriver);
+
+    try {
+      // Try with invalid status filter - should throw IllegalArgumentException
+      taskResourceManager.getMinionStatus("DISABLED", false);
+    } finally {
+      // Cleanup
+      _helixResourceManager.dropInstance("Minion_" + minionHost + "_" + minionPort);
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core;
 
 import com.google.common.collect.BiMap;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.HelixAdmin;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
 import org.apache.helix.model.ClusterConfig;
@@ -58,6 +61,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.api.resources.InstanceInfo;
 import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
@@ -75,6 +79,10 @@ import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
+import org.apache.pinot.spi.stream.PartitionGroupMetadata;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.CommonConstants.Segment;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
@@ -88,6 +96,12 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 
@@ -1596,10 +1610,115 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     assertEquals(actualSet, new HashSet<>(Arrays.asList(expected)));
   }
 
+  @Test
+  public void testGetConsumerWatermarks()
+      throws Exception {
+    String rawTableName = "watermarksTable";
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+
+    // Test table not found
+    assertThrows(TableNotFoundException.class, () -> _helixResourceManager.getConsumerWatermarks(rawTableName));
+
+    // Setup table
+    addDummySchema(rawTableName);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(rawTableName).setBrokerTenant(BROKER_TENANT_NAME)
+            .setServerTenant(SERVER_TENANT_NAME)
+            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap()).build();
+    _helixResourceManager.addTable(tableConfig);
+
+    // Setup mocks
+    PinotLLCRealtimeSegmentManager mockSegmentManager = mock(PinotLLCRealtimeSegmentManager.class);
+    Field llcManagerField = PinotHelixResourceManager.class.getDeclaredField("_pinotLLCRealtimeSegmentManager");
+    llcManagerField.setAccessible(true);
+    PinotLLCRealtimeSegmentManager originalLlcManager =
+        (PinotLLCRealtimeSegmentManager) llcManagerField.get(_helixResourceManager);
+    llcManagerField.set(_helixResourceManager, mockSegmentManager);
+
+    Field helixAdminField = PinotHelixResourceManager.class.getDeclaredField("_helixAdmin");
+    helixAdminField.setAccessible(true);
+    HelixAdmin originalHelixAdmin = (HelixAdmin) helixAdminField.get(_helixResourceManager);
+    HelixAdmin spyHelixAdmin = spy(originalHelixAdmin);
+    helixAdminField.set(_helixResourceManager, spyHelixAdmin);
+
+    IdealState idealState = new IdealState(realtimeTableName);
+    doReturn(idealState).when(spyHelixAdmin).getResourceIdealState(any(), eq(realtimeTableName));
+
+    // Test happy path
+    PartitionGroupConsumptionStatus doneStatus = new PartitionGroupConsumptionStatus(0, 100,
+        new LongMsgOffset(123), new LongMsgOffset(456), "done");
+    PartitionGroupConsumptionStatus inProgressStatus =
+        new PartitionGroupConsumptionStatus(1, 200, new LongMsgOffset(789), null, "IN_PROGRESS");
+    when(mockSegmentManager.getPartitionGroupConsumptionStatusList(any(), any()))
+        .thenReturn(Arrays.asList(doneStatus, inProgressStatus));
+
+    WatermarkInductionResult waterMarkInductionResult = _helixResourceManager.getConsumerWatermarks(rawTableName);
+    assertEquals(waterMarkInductionResult.getWatermarks().size(), 2);
+    WatermarkInductionResult.Watermark doneWatermark = waterMarkInductionResult.getWatermarks().get(0);
+    assertEquals(doneWatermark.getPartitionGroupId(), 0);
+    assertEquals(doneWatermark.getSequenceNumber(), 101L);
+    assertEquals(doneWatermark.getOffset(), 456L);
+    WatermarkInductionResult.Watermark inProgressWatermark = waterMarkInductionResult.getWatermarks().get(1);
+    assertEquals(inProgressWatermark.getPartitionGroupId(), 1);
+    assertEquals(inProgressWatermark.getSequenceNumber(), 200L);
+    assertEquals(inProgressWatermark.getOffset(), 789L);
+
+    // recover the original values
+    helixAdminField.set(_helixResourceManager, originalHelixAdmin);
+    llcManagerField.set(_helixResourceManager, originalLlcManager);
+    // Cleanup
+    _helixResourceManager.deleteRealtimeTable(rawTableName);
+    deleteSchema(rawTableName);
+  }
+
   @AfterClass
   public void tearDown() {
     stopFakeInstances();
     stopController();
     stopZk();
+  }
+
+  @Test
+  public void testAddRealtimeTableWithConsumingMetadata()
+      throws Exception {
+    final String rawTableName = "testTable2";
+    final String realtimeTableName = rawTableName + "_REALTIME";
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(rawTableName).setBrokerTenant(BROKER_TENANT_NAME)
+            .setServerTenant(SERVER_TENANT_NAME)
+            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap()).build();
+    waitForEVToDisappear(tableConfig.getTableName());
+    addDummySchema(rawTableName);
+
+    List<Pair<PartitionGroupMetadata, Integer>> consumingMetadata = new ArrayList<>();
+    PartitionGroupMetadata metadata0 = mock(PartitionGroupMetadata.class);
+    when(metadata0.getPartitionGroupId()).thenReturn(0);
+    when(metadata0.getStartOffset()).thenReturn(mock(StreamPartitionMsgOffset.class));
+    consumingMetadata.add(Pair.of(metadata0, 5));
+    PartitionGroupMetadata metadata1 = mock(PartitionGroupMetadata.class);
+    when(metadata1.getPartitionGroupId()).thenReturn(1);
+    when(metadata1.getStartOffset()).thenReturn(mock(StreamPartitionMsgOffset.class));
+    consumingMetadata.add(Pair.of(metadata1, 10));
+
+    _helixResourceManager.addTable(tableConfig, consumingMetadata);
+
+    IdealState idealState = _helixResourceManager.getTableIdealState(realtimeTableName);
+    assertNotNull(idealState);
+    assertEquals(idealState.getPartitionSet().size(), 2);
+
+    for (String segmentName : idealState.getPartitionSet()) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      int partitionGroupId = llcSegmentName.getPartitionGroupId();
+      if (partitionGroupId == 0) {
+        assertEquals(llcSegmentName.getSequenceNumber(), 5);
+      } else if (partitionGroupId == 1) {
+        assertEquals(llcSegmentName.getSequenceNumber(), 10);
+      } else {
+        fail("Unexpected partition group id: " + partitionGroupId);
+      }
+    }
+
+    _helixResourceManager.deleteRealtimeTable(rawTableName);
+    deleteSchema(rawTableName);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RealtimeSegmentCopierTest {
+
+  @Mock
+  private ControllerConf _controllerConf;
+  @Mock
+  private HttpClient _httpClient;
+  @Mock
+  private PinotFS _pinotFS;
+
+  private RealtimeSegmentCopier _copier;
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    when(_controllerConf.getDataDir()).thenReturn("hdfs://data");
+    _copier = spy(new RealtimeSegmentCopier(_controllerConf, _httpClient));
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testCopy() throws Exception {
+    String tableNameWithType = "table1_REALTIME";
+    String segmentName = "seg1";
+    CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("segment.download.url", "hdfs://src/data/seg1");
+
+    doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
+    when(_pinotFS.exists(any(URI.class))).thenReturn(false);
+
+    SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+    when(response.getStatusCode()).thenReturn(200);
+    when(_httpClient.sendJsonPostRequest(any(URI.class), anyString(), anyMap())).thenReturn(response);
+
+    _copier.copy(tableNameWithType, segmentName, payload, metadata);
+
+    verify(_pinotFS).copy(any(URI.class), any(URI.class));
+    verify(_httpClient).sendJsonPostRequest(any(URI.class), anyString(), anyMap());
+  }
+
+  @Test
+  public void testCopyExisting() throws Exception {
+    String tableNameWithType = "table1_REALTIME";
+    String segmentName = "seg1";
+    CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("segment.download.url", "hdfs://src/data/seg1");
+
+    doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
+    when(_pinotFS.exists(any(URI.class))).thenReturn(true);
+
+    SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+    when(response.getStatusCode()).thenReturn(200);
+    when(_httpClient.sendJsonPostRequest(any(URI.class), anyString(), anyMap())).thenReturn(response);
+
+    _copier.copy(tableNameWithType, segmentName, payload, metadata);
+
+    verify(_pinotFS, never()).copy(any(URI.class), any(URI.class));
+    verify(_httpClient).sendJsonPostRequest(any(URI.class), anyString(), anyMap());
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStatsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStatsTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TableReplicationProgressStatsTest {
+
+  @Test
+  public void testStats() {
+    TableReplicationProgressStats stats = new TableReplicationProgressStats(10);
+    Assert.assertEquals(stats.getRemainingSegments(), 10);
+    Assert.assertTrue(stats.getSegmentsFailToCopy().isEmpty());
+
+    stats.updateSegmentStatus("seg1", TableReplicationProgressStats.SegmentStatus.COMPLETED);
+    Assert.assertEquals(stats.getRemainingSegments(), 9);
+    Assert.assertTrue(stats.getSegmentsFailToCopy().isEmpty());
+
+    stats.updateSegmentStatus("seg2", TableReplicationProgressStats.SegmentStatus.ERROR);
+    Assert.assertEquals(stats.getRemainingSegments(), 8);
+    List<String> failedSegments = stats.getSegmentsFailToCopy();
+    Assert.assertEquals(failedSegments.size(), 1);
+    Assert.assertEquals(failedSegments.get(0), "seg2");
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
@@ -102,16 +101,16 @@ public class TableReplicatorTest {
     when(response.getStatusCode()).thenReturn(200);
 
     when(_httpClient.sendGetRequest(any(URI.class), anyMap())).thenReturn(response);
-    when(_pinotHelixResourceManager.addNewSegmentCopyXClusterJob(anyString(), anyString(), anyLong(), anyList()))
-        .thenReturn(true);
+    when(_pinotHelixResourceManager.addNewTableReplicationJob(anyString(), anyString(), anyLong(),
+        any(WatermarkInductionResult.class))).thenReturn(true);
 
     _tableReplicator.replicateTable(jobId, tableName, copyTablePayload, watermarkInductionResult);
 
-    ArgumentCaptor<List> segmentsCaptor = ArgumentCaptor.forClass(List.class);
-    verify(_pinotHelixResourceManager).addNewSegmentCopyXClusterJob(eq(tableName), eq(jobId), anyLong(),
-        segmentsCaptor.capture());
+    ArgumentCaptor<WatermarkInductionResult> resultCaptor = ArgumentCaptor.forClass(WatermarkInductionResult.class);
+    verify(_pinotHelixResourceManager).addNewTableReplicationJob(eq(tableName), eq(jobId), anyLong(),
+        resultCaptor.capture());
 
-    List<String> capturedSegments = segmentsCaptor.getValue();
+    List<String> capturedSegments = resultCaptor.getValue().getHistoricalSegments();
     Assert.assertEquals(capturedSegments.size(), 2);
     Assert.assertTrue(capturedSegments.contains("seg1"));
     Assert.assertTrue(capturedSegments.contains("seg2"));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TableReplicatorTest {
+
+  @Mock
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+  @Mock
+  private ExecutorService _executorService;
+  @Mock
+  private SegmentCopier _segmentCopier;
+  @Mock
+  private HttpClient _httpClient;
+
+  private TableReplicator _tableReplicator;
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    _tableReplicator = new TableReplicator(_pinotHelixResourceManager, _executorService, _segmentCopier, _httpClient);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testReplicateTable() throws Exception {
+    String jobId = "job1";
+    String tableName = "table1_REALTIME";
+    String sourceClusterUri = "http://localhost:9000";
+    CopyTablePayload copyTablePayload = new CopyTablePayload(sourceClusterUri, Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+
+    WatermarkInductionResult watermarkInductionResult = new WatermarkInductionResult(Collections.emptyList(),
+        Arrays.asList("seg1", "seg2"));
+
+    // Mock HttpClient response for ZK metadata
+    Map<String, Map<String, String>> zkMetadataMap = new HashMap<>();
+    Map<String, String> seg1Metadata = new HashMap<>();
+    seg1Metadata.put("k1", "v1");
+    zkMetadataMap.put("seg1", seg1Metadata);
+
+    Map<String, String> seg2Metadata = new HashMap<>();
+    seg2Metadata.put("k2", "v2");
+    zkMetadataMap.put("seg2", seg2Metadata);
+
+    String zkMetadataJson = new ObjectMapper().writeValueAsString(zkMetadataMap);
+    SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+    when(response.getResponse()).thenReturn(zkMetadataJson);
+    when(response.getStatusCode()).thenReturn(200);
+
+    when(_httpClient.sendGetRequest(any(URI.class), anyMap())).thenReturn(response);
+    when(_pinotHelixResourceManager.addNewSegmentCopyXClusterJob(anyString(), anyString(), anyLong(), anyList()))
+        .thenReturn(true);
+
+    _tableReplicator.replicateTable(jobId, tableName, copyTablePayload, watermarkInductionResult);
+
+    ArgumentCaptor<List> segmentsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(_pinotHelixResourceManager).addNewSegmentCopyXClusterJob(eq(tableName), eq(jobId), anyLong(),
+        segmentsCaptor.capture());
+
+    List<String> capturedSegments = segmentsCaptor.getValue();
+    Assert.assertEquals(capturedSegments.size(), 2);
+    Assert.assertTrue(capturedSegments.contains("seg1"));
+    Assert.assertTrue(capturedSegments.contains("seg2"));
+
+    verify(_executorService, times(4)).submit(any(Runnable.class));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.controller.helix.core.replication;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
 import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.ArgumentCaptor;
@@ -61,9 +63,10 @@ public class ZkBasedTableReplicationObserverTest {
     String jobId = "job1";
     String tableName = "table1";
     List<String> segments = Arrays.asList("seg1", "seg2", "seg3");
+    WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
 
     ZkBasedTableReplicationObserver observer =
-        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+        new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
 
     // Trigger completion (1st segment) - no ZK update (only every 100 or error)
     // Total 3. remaining starts at 3.
@@ -93,9 +96,10 @@ public class ZkBasedTableReplicationObserverTest {
     String jobId = "job1";
     String tableName = "table1";
     List<String> segments = Arrays.asList("seg1");
+    WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
 
     ZkBasedTableReplicationObserver observer =
-        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+        new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
 
     observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, "seg1");
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class ZkBasedTableReplicationObserverTest {
+
+  @Mock
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testObserver() {
+    String jobId = "job1";
+    String tableName = "table1";
+    List<String> segments = Arrays.asList("seg1", "seg2", "seg3");
+
+    ZkBasedTableReplicationObserver observer =
+        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+
+    // Trigger completion (1st segment) - no ZK update (only every 100 or error)
+    // Total 3. remaining starts at 3.
+    // complete seg1 -> remaining 2. 2 % 100 != 0.
+    // complete seg2 -> remaining 1.
+    // complete seg3 -> remaining 0. 0 % 100 == 0 -> ZK update.
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg1");
+    verify(_pinotHelixResourceManager, never()).addControllerJobToZK(anyString(), anyMap(), any());
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg2");
+    verify(_pinotHelixResourceManager, never()).addControllerJobToZK(anyString(), anyMap(), any());
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg3");
+
+    ArgumentCaptor<Map<String, String>> metadataCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(_pinotHelixResourceManager).addControllerJobToZK(eq(jobId), metadataCaptor.capture(),
+        eq(ControllerJobTypes.TABLE_REPLICATION));
+
+    Map<String, String> metadata = metadataCaptor.getValue();
+    Assert.assertEquals(metadata.get(CommonConstants.ControllerJob.JOB_ID), jobId);
+    Assert.assertEquals(metadata.get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE), tableName);
+  }
+
+  @Test
+  public void testObserverError() {
+    String jobId = "job1";
+    String tableName = "table1";
+    List<String> segments = Arrays.asList("seg1");
+
+    ZkBasedTableReplicationObserver observer =
+        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, "seg1");
+
+    verify(_pinotHelixResourceManager).addControllerJobToZK(eq(jobId), anyMap(),
+        eq(ControllerJobTypes.TABLE_REPLICATION));
+  }
+}

--- a/pinot-controller/src/test/resources/table/table_config_with_instance_assignment.json
+++ b/pinot-controller/src/test/resources/table/table_config_with_instance_assignment.json
@@ -1,0 +1,15 @@
+{
+  "tenants": {
+    "broker": "broker1",
+    "server": "server1"
+  },
+  "instanceAssignmentConfigMap": {
+    "CONSUMING": {
+      "tagPoolConfig": {
+        "tag": "server1_REALTIME",
+        "poolBased": true,
+        "numPools": 2
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -105,6 +105,7 @@ public class Actions {
     public static final String DELETE_QUERY_WORKLOAD_CONFIG = "DeleteQueryWorkloadConfig";
     public static final String GET_GROOVY_STATIC_ANALYZER_CONFIG = "GetGroovyStaticAnalyzerConfig";
     public static final String UPDATE_GROOVY_STATIC_ANALYZER_CONFIG = "UpdateGroovyStaticAnalyzerConfig";
+    public static final String GET_TABLE_COPY_STATUS = "GetTableCopyStatus";
   }
 
   // Action names for table

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
@@ -121,7 +121,7 @@ public final class BasicAuthPrincipalUtils {
           Set<String> excludeTables = Optional.ofNullable(user.getExcludeTables())
               .orElseGet(() -> Collections.emptyList())
               .stream().collect(Collectors.toSet());
-          Set<String> permissions = Optional.ofNullable(user.getPermissios())
+          Set<String> permissions = Optional.ofNullable(user.getPermissions())
               .orElseGet(() -> Collections.emptyList())
               .stream().map(x -> x.toString())
               .collect(Collectors.toSet());

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/ZkBasicAuthPrincipal.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/ZkBasicAuthPrincipal.java
@@ -24,41 +24,42 @@ import java.util.Set;
 import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.RoleType;
 
+
 /**
  * Container object for basic auth principal
  */
 public class ZkBasicAuthPrincipal extends BasicAuthPrincipal {
-    private final String _password;
-    private final String _component;
-    private final String _role;
+  private final String _password;
+  private final String _component;
+  private final String _role;
 
-    public ZkBasicAuthPrincipal(String name, String token, String password, String component, String role,
-        Set<String> tables, Set<String> excludeTables, Set<String> permissions) {
-     this(name, token, password, component, role, tables, excludeTables, permissions, null);
-    }
+  public ZkBasicAuthPrincipal(String name, String token, String password, String component, String role,
+      Set<String> tables, Set<String> excludeTables, Set<String> permissions) {
+    this(name, token, password, component, role, tables, excludeTables, permissions, null);
+  }
 
-    public ZkBasicAuthPrincipal(String name, String token, String password, String component, String role,
-        Set<String> tables, Set<String> excludeTables, Set<String> permissions,
-        Map<String, List<String>> tableRLSFilters) {
-        super(name, token, tables, excludeTables, permissions, tableRLSFilters);
-        _component = component;
-        _role = role;
-        _password = password;
-    }
+  public ZkBasicAuthPrincipal(String name, String token, String password, String component, String role,
+      Set<String> tables, Set<String> excludeTables, Set<String> permissions,
+      Map<String, List<String>> tableRLSFilters) {
+    super(name, token, tables, excludeTables, permissions, tableRLSFilters);
+    _component = component;
+    _role = role;
+    _password = password;
+  }
 
-    public String getRole() {
-        return _role;
-    }
+  public String getRole() {
+    return _role;
+  }
 
-    public String getComponent() {
-        return _component;
-    }
+  public String getComponent() {
+    return _component;
+  }
 
-    public String getPassword() {
-        return _password;
-    }
+  public String getPassword() {
+    return _password;
+  }
 
-    public boolean hasPermission(RoleType role, ComponentType component) {
-        return RoleType.valueOf(_role).equals(role) && ComponentType.valueOf(_component).equals(component);
-    }
+  public boolean hasPermission(RoleType role, ComponentType component) {
+    return RoleType.valueOf(_role).equals(role) && ComponentType.valueOf(_component).equals(component);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -64,6 +64,7 @@ import org.apache.pinot.common.utils.config.TierConfigUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.UpsertInconsistentStateConfig;
 import org.apache.pinot.core.util.PeerServerSegmentFinder;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.StaleSegment;
@@ -81,7 +82,6 @@ import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.segment.local.utils.SegmentOperationsThrottler;
 import org.apache.pinot.segment.local.utils.SegmentReloadSemaphore;
 import org.apache.pinot.segment.local.utils.ServerReloadJobStatusCache;
-import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -819,21 +819,21 @@ public abstract class BaseTableDataManager implements TableDataManager {
     if (segmentDataManager instanceof RealtimeSegmentDataManager) {
       // Use force commit to reload consuming segment
       if (_instanceDataManagerConfig.shouldReloadConsumingSegment()) {
-        // For partial-upsert tables or upserts with out-of-order events enabled, force-committing
-        // consuming segments is disabled. In some cases (especially when replication > 1), the
-        // server that consumed fewer rows was incorrectly selected as the winner, causing other
-        // servers to reconsume rows and resulting in inconsistent data when previous state must
-        // be referenced for add/update operations.
-        // TODO: Temporarily disabled until a proper fix is implemented.
+        // Force-committing consuming segments is enabled by default.
+        // For partial-upsert tables or upserts with out-of-order events enabled (notably when replication > 1),
+        // winner selection could incorrectly favor replicas with fewer consumed rows.
+        // This triggered unnecessary reconsumption and resulted in inconsistent upsert state.
+        // The new fix restores and correct segment metadata after inconsistencies are noticed.
+        // To toggle, existing Force commit behavior dynamically use the cluster config
+        // `pinot.server.upsert.force.commit.reload` without restarting servers.
         TableConfig tableConfig = indexLoadingConfig.getTableConfig();
-        if (TableConfigUtils.checkForInconsistentStateConfigs(tableConfig)) {
-          _logger.warn(
-              "Skipping reload (force committing) on consuming segment: {} for a Partial Upsert Table/ upsert tables "
-                  + "when dropOutOfOrder is enabled with no consistency mode",
-              segmentName);
-        } else {
+        UpsertInconsistentStateConfig config = UpsertInconsistentStateConfig.getInstance();
+        if (tableConfig != null && config.isForceCommitReloadAllowed(tableConfig)) {
           _logger.info("Reloading (force committing) consuming segment: {}", segmentName);
           ((RealtimeSegmentDataManager) segmentDataManager).forceCommit();
+        } else {
+          _logger.warn("Skipping reload (force commit) on consuming segment: {} due to inconsistent state config. "
+              + "Control via cluster config: {}", segmentName, config.getConfigKey());
         }
       } else {
         _logger.warn("Skip reloading consuming segment: {} as configured", segmentName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1659,8 +1659,16 @@ public abstract class BaseTableDataManager implements TableDataManager {
     return segmentDirectoryLoader.load(indexDir.toURI(), loaderContext);
   }
 
+  // CRC check can be performed on both segment CRC and data CRC (if available) based on the ZK property value of
+  // useDataCRC.
   private static boolean hasSameCRC(SegmentZKMetadata zkMetadata, SegmentMetadata localMetadata) {
-    return zkMetadata.getCrc() == Long.parseLong(localMetadata.getCrc());
+    if (zkMetadata.getCrc() == Long.parseLong(localMetadata.getCrc())) {
+      return true;
+    }
+    return zkMetadata.isUseDataCrc()
+            && zkMetadata.getDataCrc() >= 0
+            && Long.parseLong(localMetadata.getDataCrc()) >= 0
+            && zkMetadata.getDataCrc() == Long.parseLong(localMetadata.getDataCrc());
   }
 
   private static void recoverReloadFailureQuietly(String tableNameWithType, String segmentName, File indexDir) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1009,7 +1009,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private boolean startSegmentCommit() {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId).withReason(_stopReason);
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReason(_stopReason);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }
@@ -1295,7 +1295,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId);
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }
@@ -1308,7 +1308,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId).withReason(_stopReason)
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReason(_stopReason)
         .withBuildTimeMillis(_segmentBuildDescriptor.getBuildTimeMillis())
         .withSegmentSizeBytes(_segmentBuildDescriptor.getSegmentSizeBytes())
         .withWaitTimeMillis(_segmentBuildDescriptor.getWaitTimeMillis());
@@ -1447,7 +1447,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     // Retry maybe once if leader is not found.
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withStreamPartitionMsgOffset(_currentOffset.toString()).withSegmentName(_segmentNameStr)
-        .withReason(_stopReason).withNumRows(_numRowsConsumed).withInstanceId(_instanceId);
+        .withReason(_stopReason).withNumRows(_numRowsIndexed).withInstanceId(_instanceId);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/UpsertInconsistentStateConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/UpsertInconsistentStateConfig.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.CommonConstants.ConfigChangeListenerConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Singleton class to manage the configuration for force commit and reload on consuming segments
+ * for upsert tables with inconsistent state configurations (partial upsert or dropOutOfOrderRecord=true
+ * with consistency mode NONE and replication > 1).
+ *
+ * This configuration is dynamically updatable via ZK cluster config without requiring a server restart.
+ */
+public class UpsertInconsistentStateConfig implements PinotClusterConfigChangeListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpsertInconsistentStateConfig.class);
+  private static final UpsertInconsistentStateConfig INSTANCE = new UpsertInconsistentStateConfig();
+
+  private final AtomicBoolean _forceCommitReloadEnabled =
+      new AtomicBoolean(ConfigChangeListenerConstants.DEFAULT_FORCE_COMMIT_RELOAD);
+
+  private UpsertInconsistentStateConfig() {
+  }
+
+  public static UpsertInconsistentStateConfig getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Checks if force commit/reload is allowed for the given table config.
+   *
+   * @param tableConfig the table config to check, may be null
+   * @return true if force commit/reload is allowed (either globally enabled or table has no inconsistent configs)
+   */
+  public boolean isForceCommitReloadAllowed(@Nullable TableConfig tableConfig) {
+    if (tableConfig == null) {
+      return false;
+    }
+    if (_forceCommitReloadEnabled.get()) {
+      return true;
+    }
+    // Allow if table doesn't have inconsistent state configs
+    return !TableConfigUtils.checkForInconsistentStateConfigs(tableConfig);
+  }
+
+  /**
+   * Returns whether force commit/reload is currently enabled globally.
+   */
+  public boolean isForceCommitReloadEnabled() {
+    return _forceCommitReloadEnabled.get();
+  }
+
+  /**
+   * Returns the current config key used for this setting.
+   */
+  public String getConfigKey() {
+    return ConfigChangeListenerConstants.FORCE_COMMIT_RELOAD_CONFIG;
+  }
+
+  @Override
+  public void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+    if (!changedConfigs.contains(ConfigChangeListenerConstants.FORCE_COMMIT_RELOAD_CONFIG)) {
+      return;
+    }
+
+    String configValue = clusterConfigs.get(ConfigChangeListenerConstants.FORCE_COMMIT_RELOAD_CONFIG);
+    boolean forceCommitReloadAllowed = (configValue == null)
+        ? ConfigChangeListenerConstants.DEFAULT_FORCE_COMMIT_RELOAD
+        : Boolean.parseBoolean(configValue);
+
+    boolean previousValue = _forceCommitReloadEnabled.getAndSet(forceCommitReloadAllowed);
+    if (previousValue != forceCommitReloadAllowed) {
+      LOGGER.info("Updated cluster config: {} from {} to {}",
+          ConfigChangeListenerConstants.FORCE_COMMIT_RELOAD_CONFIG, previousValue, forceCommitReloadAllowed);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -64,6 +65,15 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
   protected abstract Object convertToSketch(DictIdsWrapper dictIdsWrapper);
 
   protected abstract IllegalStateException getIllegalDataTypeException(DataType dataType, boolean singleValue);
+
+  /**
+   * Returns the dictionary cardinality threshold for adaptive conversion.
+   * If the cardinality exceeds this threshold, the bitmap is converted to a sketch.
+   * Return Integer.MAX_VALUE to disable adaptive conversion during aggregation.
+   */
+  protected int getDictIdCardinalityThreshold() {
+    return Integer.MAX_VALUE;
+  }
 
   @Override
   public final AggregationResultHolder createAggregationResultHolder() {
@@ -202,17 +212,21 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
 
     Dictionary dictionary = blockValSet.getDictionary();
     if (dictionary != null) {
+      // Track which groups were modified to check cardinality only once per group per batch
+      IntSet modifiedGroups = new IntOpenHashSet();
       if (blockValSet.isSingleValue()) {
         int[] dictIds = blockValSet.getDictionaryIdsSV();
         for (int i = 0; i < length; i++) {
-          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+          aggregateDictIdForGroup(groupByResultHolder, groupKeyArray[i], dictionary, dictIds[i], modifiedGroups);
         }
       } else {
         int[][] dictIds = blockValSet.getDictionaryIdsMV();
         for (int i = 0; i < length; i++) {
-          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+          aggregateDictIdsForGroup(groupByResultHolder, groupKeyArray[i], dictionary, dictIds[i], modifiedGroups);
         }
       }
+      // Check cardinality only once per modified group after all additions
+      checkAndConvertToSketchForGroups(groupByResultHolder, modifiedGroups);
       return;
     }
 
@@ -335,19 +349,25 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
 
     Dictionary dictionary = blockValSet.getDictionary();
     if (dictionary != null) {
+      // Track which groups were modified to check cardinality only once per group per batch
+      IntSet modifiedGroups = new IntOpenHashSet();
       if (blockValSet.isSingleValue()) {
         int[] dictIds = blockValSet.getDictionaryIdsSV();
         for (int i = 0; i < length; i++) {
-          setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
+          for (int groupKey : groupKeysArray[i]) {
+            aggregateDictIdForGroup(groupByResultHolder, groupKey, dictionary, dictIds[i], modifiedGroups);
+          }
         }
       } else {
         int[][] dictIds = blockValSet.getDictionaryIdsMV();
         for (int i = 0; i < length; i++) {
           for (int groupKey : groupKeysArray[i]) {
-            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+            aggregateDictIdsForGroup(groupByResultHolder, groupKey, dictionary, dictIds[i], modifiedGroups);
           }
         }
       }
+      // Check cardinality only once per modified group after all additions
+      checkAndConvertToSketchForGroups(groupByResultHolder, modifiedGroups);
       return;
     }
 
@@ -667,6 +687,62 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       default:
         throw new IllegalStateException(
             "Illegal data type for DISTINCT_COUNT_SMART aggregation function: " + storedType);
+    }
+  }
+
+  /**
+   * Aggregate a single dictionary ID for a group. If already a sketch, offer directly.
+   * Otherwise add to bitmap and track as modified.
+   */
+  private void aggregateDictIdForGroup(GroupByResultHolder groupByResultHolder, int groupKey, Dictionary dictionary,
+      int dictId, IntSet modifiedGroups) {
+    Object result = groupByResultHolder.getResult(groupKey);
+    if (result == null || result instanceof DictIdsWrapper) {
+      // Null or still using bitmap, add dict ID
+      getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictId);
+      modifiedGroups.add(groupKey);
+    } else {
+      // Already converted to sketch, offer directly
+      ((HyperLogLog) result).offer(dictionary.get(dictId));
+    }
+  }
+
+  /**
+   * Aggregate multiple dictionary IDs for a group. If already a sketch, offer directly.
+   * Otherwise add to bitmap and track as modified.
+   */
+  private void aggregateDictIdsForGroup(GroupByResultHolder groupByResultHolder, int groupKey, Dictionary dictionary,
+      int[] dictIds, IntSet modifiedGroups) {
+    Object result = groupByResultHolder.getResult(groupKey);
+    if (result == null || result instanceof DictIdsWrapper) {
+      // Null or still using bitmap, add dict IDs
+      getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds);
+      modifiedGroups.add(groupKey);
+    } else {
+      // Already converted to sketch, offer directly
+      for (int dictId : dictIds) {
+        ((HyperLogLog) result).offer(dictionary.get(dictId));
+      }
+    }
+  }
+
+  /**
+   * Check and convert to sketch if cardinality threshold exceeded for group-by aggregation.
+   */
+  private void checkAndConvertToSketchForGroups(GroupByResultHolder groupByResultHolder, IntSet modifiedGroups) {
+    int threshold = getDictIdCardinalityThreshold();
+    // Skip conversion check if adaptive conversion is disabled (threshold is Integer.MAX_VALUE)
+    if (threshold == Integer.MAX_VALUE) {
+      return;
+    }
+    for (int groupKey : modifiedGroups) {
+      Object result = groupByResultHolder.getResult(groupKey);
+      if (result instanceof DictIdsWrapper) {
+        DictIdsWrapper dictIdsWrapper = (DictIdsWrapper) result;
+        if (dictIdsWrapper._dictIdBitmap.getCardinality() > threshold) {
+          groupByResultHolder.setValueForKey(groupKey, convertToSketch(dictIdsWrapper));
+        }
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessorUtils.java
@@ -73,9 +73,9 @@ public final class SegmentProcessorUtils {
       }
     }
 
-    metricFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
-    fieldSpecs.addAll(nonMetricFieldSpecs);
     nonMetricFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
+    fieldSpecs.addAll(nonMetricFieldSpecs);
+    metricFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
     fieldSpecs.addAll(metricFieldSpecs);
 
     int numSortFields;

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
@@ -94,7 +94,7 @@ public class ZkBasicAuthAccessFactory implements AccessControlFactory {
       Collection<String> tokens = getTokens(requesterIdentity);
       _name2principal =
           BasicAuthPrincipalUtils.extractBasicAuthPrincipals(_userCache.getAllServerUserConfig()).stream()
-          .collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
+              .collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
 
       Map<String, String> name2password = tokens.stream().collect(
           Collectors.toMap(BasicAuthTokenUtils::extractUsername, BasicAuthTokenUtils::extractPassword,

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
@@ -43,6 +43,40 @@ public class TestThreadMXBean {
     ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
   }
 
+  @Test
+  public void testDisableThenEnableCpuTimeMeasurement() {
+    if (!ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
+      return;
+    }
+
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadCpuTime() > 0);
+
+    ThreadResourceUsageProvider.setThreadCpuTimeMeasurementEnabled(false);
+    Assert.assertFalse(ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled());
+    Assert.assertEquals(ThreadResourceUsageProvider.getCurrentThreadCpuTime(), 0);
+
+    ThreadResourceUsageProvider.setThreadCpuTimeMeasurementEnabled(true);
+    Assert.assertTrue(ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled());
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadCpuTime() > 0);
+  }
+
+  @Test
+  public void testDisableThenEnableMemoryMeasurement() {
+    if (!ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
+      return;
+    }
+
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes() > 0);
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(false);
+    Assert.assertFalse(ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled());
+    Assert.assertEquals(ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes(), 0);
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
+    Assert.assertTrue(ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled());
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes() > 0);
+  }
+
   /**
    * simple memory allocation
    */

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class DistinctCountSmartHLLAggregationFunctionTest {
+
+  @Test
+  public void testParameterParsing() {
+    // Test default values
+    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col")));
+    assertEquals(function.getThreshold(), 100_000);
+    assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
+
+    // Test individual parameters
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=50000")));
+    assertEquals(function.getThreshold(), 50_000);
+    assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
+
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8")));
+    assertEquals(function.getThreshold(), 100_000);
+    assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
+
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")));
+    assertEquals(function.getThreshold(), 100_000);
+    assertEquals(function.getDictIdCardinalityThreshold(), 50_000);
+
+    // Test disabled dictThreshold (non-positive values)
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")));
+    assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
+
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=0")));
+    assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
+
+    // Test multiple parameters together
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=200000;log2m=10;dictThreshold=150000")));
+    assertEquals(function.getThreshold(), 200_000);
+    assertEquals(function.getDictIdCardinalityThreshold(), 150_000);
+
+    // Test parameter order independence
+    DistinctCountSmartHLLAggregationFunction function1 = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000;threshold=100000;log2m=8")));
+    DistinctCountSmartHLLAggregationFunction function2 = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8;dictThreshold=50000;threshold=100000")));
+    assertEquals(function1.getThreshold(), function2.getThreshold());
+    assertEquals(function1.getDictIdCardinalityThreshold(), function2.getDictIdCardinalityThreshold());
+
+    // Test legacy parameter names
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "hllConversionThreshold=50000;hllLog2m=10")));
+    assertEquals(function.getThreshold(), 50_000);
+
+    // Test case-insensitive parameters
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "THRESHOLD=50000;LOG2M=8;DICTTHRESHOLD=100000")));
+    assertEquals(function.getThreshold(), 50_000);
+    assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
+  }
+
+  @Test
+  public void testFunctionMetadata() {
+    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col")));
+
+    // Test function type
+    assertEquals(function.getType().getName(), "distinctCountSmartHLL");
+
+    // Test result types
+    assertEquals(function.getIntermediateResultColumnType(), DataSchema.ColumnDataType.OBJECT);
+    assertEquals(function.getFinalResultColumnType(), DataSchema.ColumnDataType.INT);
+
+    // Test result holder creation
+    assertNotNull(function.createAggregationResultHolder());
+    assertNotNull(function.createGroupByResultHolder(10, 100));
+  }
+
+  @Test
+  public void testHLLOperations() {
+    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col")));
+
+    // Test merge final results (should sum)
+    Integer finalResult = function.mergeFinalResult(100, 200);
+    assertEquals(finalResult.intValue(), 300);
+
+    // Test extract final result (HLL cardinality)
+    HyperLogLog hll = new HyperLogLog(12);
+    for (int i = 0; i < 1000; i++) {
+      hll.offer(i);
+    }
+    Long cardinality = Long.valueOf(function.extractFinalResult(hll));
+    assertNotNull(cardinality);
+    assertTrue(cardinality >= 950 && cardinality <= 1050, "Cardinality: " + cardinality);
+
+    // Test merge intermediate results (HLL union)
+    HyperLogLog hll1 = new HyperLogLog(12);
+    HyperLogLog hll2 = new HyperLogLog(12);
+    for (int i = 0; i < 500; i++) {
+      hll1.offer(i);
+    }
+    for (int i = 250; i < 750; i++) {
+      hll2.offer(i);
+    }
+    HyperLogLog merged = (HyperLogLog) function.merge(hll1, hll2);
+    assertNotNull(merged);
+    long mergedCardinality = merged.cardinality();
+    assertTrue(mergedCardinality >= 700 && mergedCardinality <= 800, "Merged cardinality: " + mergedCardinality);
+  }
+
+  @Test
+  public void testAdaptiveConversion() {
+    // Test adaptive conversion enabled by default (100K threshold)
+    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col")));
+    assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
+
+    // Test adaptive conversion with custom threshold
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")));
+    assertEquals(function.getDictIdCardinalityThreshold(), 50_000);
+
+    // Test adaptive conversion disabled (Integer.MAX_VALUE)
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=" + Integer.MAX_VALUE)));
+    assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
+
+    // Test non-positive threshold converted to Integer.MAX_VALUE (disabled)
+    function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")));
+    assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
+  }
+}

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -591,10 +591,10 @@ public abstract class ClusterTest extends ControllerTest {
 
   public JsonNode postTimeseriesQuery(String baseUrl, String query, long startTime, long endTime,
       Map<String, String> headers) {
-    return postTimeseriesQuery(baseUrl, query, startTime, endTime, headers, null);
+    return postTimeseriesQuery(baseUrl, query, startTime, endTime, null, headers, null);
   }
 
-  public JsonNode postTimeseriesQuery(String baseUrl, String query, long startTime, long endTime,
+  public JsonNode postTimeseriesQuery(String baseUrl, String query, long startTime, long endTime, String mode,
       Map<String, String> headers, Map<String, Object> queryOptions) {
     try {
       ObjectNode payload = JsonUtils.newObjectNode();
@@ -602,6 +602,9 @@ public abstract class ClusterTest extends ControllerTest {
       payload.put("query", query);
       payload.put("start", String.valueOf(startTime));
       payload.put("end", String.valueOf(endTime));
+      if (mode != null) {
+        payload.put("mode", mode);
+      }
       if (queryOptions != null && !queryOptions.isEmpty()) {
         ObjectNode queryOptionsNode = JsonUtils.newObjectNode();
         queryOptions.forEach(queryOptionsNode::putPOJO);

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -117,6 +117,7 @@ public abstract class ClusterTest extends ControllerTest {
   protected String _minionBaseApiUrl;
 
   protected boolean _useMultiStageQueryEngine = false;
+  protected boolean _usePhysicalOptimizer = false;
 
   protected int getServerGrpcPort() {
     return _serverGrpcPort;
@@ -146,8 +147,16 @@ public abstract class ClusterTest extends ControllerTest {
     return _useMultiStageQueryEngine;
   }
 
+  protected boolean usePhysicalOptimizer() {
+    return _usePhysicalOptimizer;
+  }
+
   protected void setUseMultiStageQueryEngine(boolean useMultiStageQueryEngine) {
     _useMultiStageQueryEngine = useMultiStageQueryEngine;
+  }
+
+  protected void setUsePhysicalOptimizer(boolean usePhysicalOptimizer) {
+    _usePhysicalOptimizer = usePhysicalOptimizer;
   }
 
   protected void disableMultiStageQueryEngine() {
@@ -826,7 +835,11 @@ public abstract class ClusterTest extends ControllerTest {
     if (!useMultiStageQueryEngine()) {
       return Map.of();
     }
-    return Map.of("queryOptions", "useMultistageEngine=true");
+    StringBuilder queryOptions = new StringBuilder("useMultistageEngine=true");
+    if (usePhysicalOptimizer()) {
+      queryOptions.append("; usePhysicalOptimizer=true");
+    }
+    return Map.of("queryOptions", queryOptions.toString());
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseQueryKillingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseQueryKillingIntegrationTest.java
@@ -77,7 +77,7 @@ public abstract class BaseQueryKillingIntegrationTest extends BaseClusterIntegra
       "SET sortAggregateSingleThreadedNumSegmentsThreshold=10000; SET sortAggregateLimitThreshold=3000001; "
           + "SELECT DISTINCT_COUNT_HLL(intDimSV1, 14), stringDimSV2 FROM mytable GROUP BY 2 ORDER BY 2 LIMIT 3000000";
 
-  protected static final String AGGREGATE_QUERY = "SELECT DISTINCT_COUNT_HLL(intDimSV1, 14) FROM mytable";
+  protected static final String AGGREGATE_QUERY = "SELECT MIN(intDimSV1) FROM mytable";
   protected static final String SELECT_STAR_QUERY = "SELECT * FROM mytable LIMIT 5";
 
   @BeforeClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
@@ -320,15 +320,15 @@ public class TimeSeriesIntegrationTest extends BaseClusterIntegrationTest {
 
     JsonNode dataSchema = resultTable.path("dataSchema");
     JsonNode columnNames = dataSchema.path("columnNames");
-    assertEquals(columnNames.size(), 2, "Should have SQL and PLAN columns");
-    assertEquals(columnNames.get(0).asText(), "SQL");
+    assertEquals(columnNames.size(), 2, "Should have QUERY and PLAN columns");
+    assertEquals(columnNames.get(0).asText(), "QUERY");
     assertEquals(columnNames.get(1).asText(), "PLAN");
 
     JsonNode rows = resultTable.path("rows");
     assertEquals(rows.size(), 1, "Should have exactly one row");
     JsonNode row = rows.get(0);
 
-    assertEquals(row.get(0).asText(), query, "SQL should match the original query");
+    assertEquals(row.get(0).asText(), query, "QUERY should match the original query");
 
     // Verify PLAN matches expected (normalize dynamic plan IDs like "plan_2, ")
     String actualPlan = row.get(1).asText().replaceAll("plan_\\d+, ", "");

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -179,6 +179,10 @@
               <name>pinot-BenchmarkStringDictionary</name>
             </program>
             <program>
+              <mainClass>org.apache.pinot.perf.aggregation.BenchmarkDistinctCountHLLThreshold</mainClass>
+              <name>pinot-BenchmarkDistinctCountHLLThreshold</name>
+            </program>
+            <program>
               <mainClass>org.apache.pinot.perf.DictionaryDumper</mainClass>
               <name>pinot-DictionaryDumper</name>
             </program>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -206,6 +206,10 @@
               <mainClass>org.apache.pinot.perf.aggregation.SumIntAggregationFunctionBenchmark</mainClass>
               <name>pinot-SumIntAggregationFunctionBenchmark</name>
             </program>
+            <program>
+              <mainClass>org.apache.pinot.perf.BenchmarkJsonParsing</mainClass>
+              <name>pinot-BenchmarkJsonParsing</name>
+            </program>
           </programs>
           <repositoryLayout>flat</repositoryLayout>
           <repositoryName>lib</repositoryName>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonParsing.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonParsing.java
@@ -1,0 +1,282 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/**
+ * Benchmark to compare JSON parsing performance:
+ * - Old approach: bytesToJsonNode() + jsonNodeToMap() (two-step parsing)
+ * - New approach: bytesToMap() (single-step parsing)
+ *
+ * This benchmark simulates the JSON decoding path in RealtimeSegmentDataManager.consumeLoop()
+ * where JSONMessageDecoder.decode() is called for each message from the stream.
+ *
+ * Run with: mvn exec:exec -Dexec.executable="java" -Dexec.args="-cp %classpath org.apache.pinot.perf
+ * .BenchmarkJsonParsing"
+ * Or compile and run: java -jar pinot-perf/target/pinot-perf-*-shaded.jar BenchmarkJsonParsing
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 3)
+@State(Scope.Benchmark)
+public class BenchmarkJsonParsing {
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder()
+        .include(BenchmarkJsonParsing.class.getSimpleName())
+        .shouldDoGC(true);
+    new Runner(opt.build()).run();
+  }
+
+  // Simulates different JSON payload sizes
+  @Param({"small", "medium", "large", "nested"})
+  private String _payloadType;
+
+  // Number of JSON messages to pre-generate for the benchmark
+  private static final int NUM_MESSAGES = 1000;
+
+  private List<byte[]> _jsonPayloads;
+  private int _currentIndex = 0;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    _jsonPayloads = new ArrayList<>(NUM_MESSAGES);
+    Random random = new Random(42);
+
+    for (int i = 0; i < NUM_MESSAGES; i++) {
+      String json = generateJsonPayload(_payloadType, random, i);
+      _jsonPayloads.add(json.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  /**
+   * Generates different types of JSON payloads to simulate real-world streaming data.
+   */
+  private String generateJsonPayload(String type, Random random, int index) {
+    switch (type) {
+      case "small":
+        // Small payload: ~100 bytes, typical for simple events
+        return String.format(
+            "{\"id\":%d,\"timestamp\":%d,\"value\":%.2f,\"status\":\"%s\"}",
+            index,
+            System.currentTimeMillis() + random.nextInt(10000),
+            random.nextDouble() * 1000,
+            random.nextBoolean() ? "active" : "inactive"
+        );
+
+      case "medium":
+        // Medium payload: ~500 bytes, typical for user events
+        return String.format(
+            "{\"eventId\":\"%s-%d\",\"userId\":\"%s\",\"sessionId\":\"%s\","
+                + "\"timestamp\":%d,\"eventType\":\"%s\",\"properties\":{"
+                + "\"page\":\"/products/%d\",\"referrer\":\"https://example.com/search?q=%s\","
+                + "\"duration\":%d,\"scrollDepth\":%.2f,\"clicks\":%d},"
+                + "\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36\","
+                + "\"ipAddress\":\"192.168.%d.%d\",\"country\":\"US\",\"city\":\"San Francisco\"}",
+            "evt", index,
+            "user-" + random.nextInt(100000),
+            "sess-" + random.nextInt(1000000),
+            System.currentTimeMillis(),
+            randomEventType(random),
+            random.nextInt(10000),
+            randomSearchQuery(random),
+            random.nextInt(300),
+            random.nextDouble() * 100,
+            random.nextInt(20),
+            random.nextInt(256),
+            random.nextInt(256)
+        );
+
+      case "large":
+        // Large payload: ~2KB, typical for detailed analytics events
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"eventId\":\"").append("evt-").append(index).append("\",");
+        sb.append("\"timestamp\":").append(System.currentTimeMillis()).append(",");
+        sb.append("\"data\":{");
+
+        // Add 20 fields to make it large
+        for (int j = 0; j < 20; j++) {
+          if (j > 0) {
+            sb.append(",");
+          }
+          sb.append("\"field").append(j).append("\":\"")
+              .append(randomString(random, 50 + random.nextInt(50))).append("\"");
+        }
+        sb.append("},\"metrics\":{");
+
+        // Add 10 numeric metrics
+        for (int j = 0; j < 10; j++) {
+          if (j > 0) {
+            sb.append(",");
+          }
+          sb.append("\"metric").append(j).append("\":").append(random.nextDouble() * 1000);
+        }
+        sb.append("},\"tags\":[");
+
+        // Add 5 tags
+        for (int j = 0; j < 5; j++) {
+          if (j > 0) {
+            sb.append(",");
+          }
+          sb.append("\"tag-").append(random.nextInt(100)).append("\"");
+        }
+        sb.append("]}");
+        return sb.toString();
+
+      case "nested":
+        // Nested payload: ~1KB with nested objects and arrays
+        return String.format(
+            "{\"order\":{\"id\":%d,\"customer\":{\"id\":\"%s\",\"name\":\"%s\",\"email\":\"%s@example.com\"},"
+                + "\"items\":[{\"sku\":\"SKU-%d\",\"name\":\"%s\",\"price\":%.2f,\"qty\":%d},"
+                + "{\"sku\":\"SKU-%d\",\"name\":\"%s\",\"price\":%.2f,\"qty\":%d},"
+                + "{\"sku\":\"SKU-%d\",\"name\":\"%s\",\"price\":%.2f,\"qty\":%d}],"
+                + "\"shipping\":{\"method\":\"%s\",\"address\":{\"street\":\"%s\",\"city\":\"%s\","
+                + "\"state\":\"%s\",\"zip\":\"%05d\"}},\"total\":%.2f,\"currency\":\"USD\"}}",
+            index,
+            "cust-" + random.nextInt(10000),
+            randomName(random),
+            "user" + random.nextInt(10000),
+            random.nextInt(10000), randomProduct(random), random.nextDouble() * 100, random.nextInt(5) + 1,
+            random.nextInt(10000), randomProduct(random), random.nextDouble() * 100, random.nextInt(5) + 1,
+            random.nextInt(10000), randomProduct(random), random.nextDouble() * 100, random.nextInt(5) + 1,
+            random.nextBoolean() ? "express" : "standard",
+            random.nextInt(9999) + " Main St",
+            randomCity(random),
+            randomState(random),
+            random.nextInt(99999),
+            random.nextDouble() * 500 + 50
+        );
+
+      default:
+        return "{\"id\":" + index + "}";
+    }
+  }
+
+  private byte[] getNextPayload() {
+    byte[] payload = _jsonPayloads.get(_currentIndex);
+    _currentIndex = (_currentIndex + 1) % NUM_MESSAGES;
+    return payload;
+  }
+
+  /**
+   * OLD APPROACH: Two-step parsing (bytesToJsonNode + jsonNodeToMap)
+   * This was the original implementation that caused high CPU usage.
+   */
+  @Benchmark
+  public Map<String, Object> oldApproachTwoStepParsing(Blackhole blackhole)
+      throws IOException {
+    byte[] payload = getNextPayload();
+
+    // Step 1: Parse bytes to JsonNode (intermediate tree representation)
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(payload, 0, payload.length);
+
+    // Step 2: Convert JsonNode to Map
+    Map<String, Object> result = JsonUtils.jsonNodeToMap(jsonNode);
+
+    blackhole.consume(jsonNode);
+    return result;
+  }
+
+  /**
+   * NEW APPROACH: Single-step parsing (bytesToMap)
+   * This is the optimized implementation that parses directly to Map.
+   */
+  @Benchmark
+  public Map<String, Object> newApproachDirectParsing(Blackhole blackhole)
+      throws IOException {
+    byte[] payload = getNextPayload();
+
+    // Direct parsing to Map, skipping the intermediate JsonNode
+    Map<String, Object> result = JsonUtils.bytesToMap(payload, 0, payload.length);
+
+    return result;
+  }
+
+  // Helper methods for generating realistic test data
+
+  private static String randomEventType(Random random) {
+    String[] types = {"pageview", "click", "scroll", "purchase", "signup", "login", "search"};
+    return types[random.nextInt(types.length)];
+  }
+
+  private static String randomSearchQuery(Random random) {
+    String[] queries = {"laptop", "phone", "headphones", "camera", "tablet", "watch", "speaker"};
+    return queries[random.nextInt(queries.length)];
+  }
+
+  private static String randomString(Random random, int length) {
+    StringBuilder sb = new StringBuilder(length);
+    String chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    for (int i = 0; i < length; i++) {
+      sb.append(chars.charAt(random.nextInt(chars.length())));
+    }
+    return sb.toString();
+  }
+
+  private static String randomName(Random random) {
+    String[] firstNames = {"John", "Jane", "Bob", "Alice", "Charlie", "Diana", "Eve", "Frank"};
+    String[] lastNames = {"Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia", "Miller"};
+    return firstNames[random.nextInt(firstNames.length)] + " " + lastNames[random.nextInt(lastNames.length)];
+  }
+
+  private static String randomProduct(Random random) {
+    String[] products = {"Widget", "Gadget", "Device", "Tool", "Component", "Module", "Unit"};
+    String[] adjectives = {"Premium", "Standard", "Basic", "Pro", "Elite", "Ultra"};
+    return adjectives[random.nextInt(adjectives.length)] + " " + products[random.nextInt(products.length)];
+  }
+
+  private static String randomCity(Random random) {
+    String[] cities = {"New York", "Los Angeles", "Chicago", "Houston", "Phoenix", "San Francisco", "Seattle"};
+    return cities[random.nextInt(cities.length)];
+  }
+
+  private static String randomState(Random random) {
+    String[] states = {"NY", "CA", "IL", "TX", "AZ", "WA", "OR", "NV", "CO", "FL"};
+    return states[random.nextInt(states.length)];
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountHLLThreshold.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountHLLThreshold.java
@@ -1,0 +1,361 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartHLLAggregationFunction;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.roaringbitmap.RoaringBitmap;
+
+
+/**
+ * Benchmark for DistinctCountSmartHLLAggregationFunction with dictionary-encoded columns.
+ *
+ * <p>Tests the performance impact of adaptive RoaringBitmap → HLL conversion strategy
+ * across different cardinality ratios and data scales.
+ *
+ */
+@Fork(0)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 2, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkDistinctCountHLLThreshold {
+  private static final ExpressionContext EXPR = ExpressionContext.forIdentifier("col");
+  private static final int BATCH_SIZE = DocIdSetPlanNode.MAX_DOC_PER_CALL;
+
+  @Param({"true", "false"})
+  private boolean _useRoaringBitmap;
+
+  @Param({"25000000"})
+  private int _recordCount;
+
+  @Param({"10", "50", "100"})
+  private int _cardinalityRatioPercent;
+
+  private DistinctCountSmartHLLAggregationFunction _aggregationFunction;
+  private TestDictionary _dictionary;
+  private int _numBatches;
+  private int[][] _batchedDictIds;
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(BenchmarkDistinctCountHLLThreshold.class.getSimpleName())
+        .build();
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    int cardinality = (_recordCount * _cardinalityRatioPercent) / 100;
+    int dictThreshold = _useRoaringBitmap ? (cardinality + 1) : 100_000;
+
+    _aggregationFunction = new TestDistinctCountSmartHLLAggregationFunction(dictThreshold);
+    _dictionary = new TestDictionary(_recordCount);
+    _numBatches = (_recordCount + BATCH_SIZE - 1) / BATCH_SIZE;
+    _batchedDictIds = generateAllBatches(_recordCount, cardinality, BATCH_SIZE);
+  }
+
+  @Benchmark
+  public void benchmarkAggregate(Blackhole bh) {
+    AggregationResultHolder resultHolder = _aggregationFunction.createAggregationResultHolder();
+
+    for (int i = 0; i < _numBatches; i++) {
+      int[] dictIds = _batchedDictIds[i];
+      Map<ExpressionContext, BlockValSet> blockValSetMap =
+          Collections.singletonMap(EXPR, new TestBlockValSet(_dictionary, dictIds));
+      _aggregationFunction.aggregate(dictIds.length, resultHolder, blockValSetMap);
+    }
+
+    bh.consume(_aggregationFunction.extractAggregationResult(resultHolder));
+  }
+
+  private int[][] generateAllBatches(int totalRecords, int cardinality, int batchSize) {
+    int numBatches = (totalRecords + batchSize - 1) / batchSize;
+    int[][] batches = new int[numBatches][];
+    Random random = new Random(42);
+
+    int recordsGenerated = 0;
+    for (int batchIdx = 0; batchIdx < numBatches; batchIdx++) {
+      int currentBatchSize = Math.min(batchSize, totalRecords - recordsGenerated);
+      int[] dictIds = new int[currentBatchSize];
+
+      for (int i = 0; i < currentBatchSize; i++) {
+        if (random.nextDouble() < 0.7) {
+          dictIds[i] = (recordsGenerated + i) % cardinality;
+        } else {
+          dictIds[i] = random.nextInt(cardinality);
+        }
+      }
+
+      batches[batchIdx] = dictIds;
+      recordsGenerated += currentBatchSize;
+    }
+
+    return batches;
+  }
+
+  private static class TestDistinctCountSmartHLLAggregationFunction extends DistinctCountSmartHLLAggregationFunction {
+    public TestDistinctCountSmartHLLAggregationFunction(int dictThreshold) {
+      super(java.util.Arrays.asList(
+          EXPR,
+          ExpressionContext.forLiteral(DataType.STRING, String.format("dictThreshold=%d", dictThreshold))
+      ));
+    }
+  }
+
+  private static class TestDictionary implements Dictionary {
+    private final int _length;
+
+    public TestDictionary(int length) {
+      _length = length;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return true;
+    }
+
+    @Override
+    public DataType getValueType() {
+      return DataType.STRING;
+    }
+
+    @Override
+    public int length() {
+      return _length;
+    }
+
+    @Override
+    public int indexOf(String stringValue) {
+      return Integer.parseInt(stringValue.substring(6));
+    }
+
+    @Override
+    public int insertionIndexOf(String stringValue) {
+      return indexOf(stringValue);
+    }
+
+    @Override
+    public IntSet getDictIdsInRange(String lower, String upper, boolean includeLower, boolean includeUpper) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compare(int dictId1, int dictId2) {
+      return Integer.compare(dictId1, dictId2);
+    }
+
+    @Override
+    public Comparable getMinVal() {
+      return "value_0";
+    }
+
+    @Override
+    public Comparable getMaxVal() {
+      return "value_" + (_length - 1);
+    }
+
+    @Override
+    public Object getSortedValues() {
+      String[] values = new String[_length];
+      for (int i = 0; i < _length; i++) {
+        values[i] = "value_" + i;
+      }
+      return values;
+    }
+
+    @Override
+    public Object get(int dictId) {
+      return dictId;
+    }
+
+    @Override
+    public int getIntValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLongValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getFloatValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getDoubleValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BigDecimal getBigDecimalValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getStringValue(int dictId) {
+      return String.valueOf(dictId);
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  private static class TestBlockValSet implements BlockValSet {
+    private final Dictionary _dictionary;
+    private final int[] _dictIds;
+
+    public TestBlockValSet(Dictionary dictionary, int[] dictIds) {
+      _dictionary = dictionary;
+      _dictIds = dictIds;
+    }
+
+    @Override
+    public RoaringBitmap getNullBitmap() {
+      return null;
+    }
+
+    @Override
+    public DataType getValueType() {
+      return DataType.STRING;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public Dictionary getDictionary() {
+      return _dictionary;
+    }
+
+    @Override
+    public int[] getDictionaryIdsSV() {
+      return _dictIds;
+    }
+
+    @Override
+    public int[] getIntValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long[] getLongValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float[] getFloatValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double[] getDoubleValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BigDecimal[] getBigDecimalValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getStringValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[][] getBytesValuesSV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int[][] getDictionaryIdsMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int[][] getIntValuesMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long[][] getLongValuesMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float[][] getFloatValuesMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double[][] getDoubleValuesMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[][] getStringValuesMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[][][] getBytesValuesMV() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int[] getNumMVEntries() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -81,11 +81,17 @@ public class HadoopPinotFS extends BasePinotFS {
   @Override
   public boolean delete(URI segmentUri, boolean forceDelete)
       throws IOException {
-    // Returns false if we are moving a directory and that directory is not empty
+    Path path = new Path(segmentUri);
+
+    if (!_hadoopFS.exists(path)) {
+      return true;
+    }
+
     if (isDirectory(segmentUri) && listFiles(segmentUri, false).length > 0 && !forceDelete) {
       return false;
     }
-    return _hadoopFS.delete(new Path(segmentUri), true);
+
+    return _hadoopFS.delete(path, true);
   }
 
   @Override
@@ -198,7 +204,7 @@ public class HadoopPinotFS extends BasePinotFS {
         throw new RuntimeException("_hadoopFS client is not initialized when trying to copy files");
       }
       if (_hadoopFS.isDirectory(remoteFile)) {
-        throw new IllegalArgumentException(srcUri.toString() + " is a direactory");
+        throw new IllegalArgumentException(srcUri.toString() + " is a directory");
       }
       long startMs = System.currentTimeMillis();
       _hadoopFS.copyToLocalFile(remoteFile, localFile);

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
@@ -150,4 +150,306 @@ public class HadoopPinotFSTest {
           fileMetadata.stream().map(FileMetadata::getFilePath).collect(Collectors.toSet())), fileMetadata.toString());
     }
   }
+
+  @Test
+  public void testDeleteBatchWithEmptyList()
+      throws IOException {
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+
+      // Test with null list
+      Assert.assertTrue(hadoopFS.deleteBatch(null, false));
+
+      // Test with empty list
+      Assert.assertTrue(hadoopFS.deleteBatch(new ArrayList<>(), false));
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithSingleFile()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchWithSingleFile");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create a single file
+      URI testFile = new Path(baseURI.getPath(), "testFile.txt").toUri();
+      hadoopFS.touch(testFile);
+      Assert.assertTrue(hadoopFS.exists(testFile));
+
+      // Delete using deleteBatch
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(testFile);
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, false));
+
+      // Verify file is deleted
+      Assert.assertFalse(hadoopFS.exists(testFile));
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithMultipleFiles()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchWithMultipleFiles");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create multiple files
+      List<URI> urisToDelete = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        URI testFile = new Path(baseURI.getPath(), "testFile" + i + ".txt").toUri();
+        hadoopFS.touch(testFile);
+        Assert.assertTrue(hadoopFS.exists(testFile));
+        urisToDelete.add(testFile);
+      }
+
+      // Delete all files using deleteBatch
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, false));
+
+      // Verify all files are deleted
+      for (URI uri : urisToDelete) {
+        Assert.assertFalse(hadoopFS.exists(uri));
+      }
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithNonExistentFiles()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchWithNonExistentFiles");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create list with non-existent files
+      List<URI> urisToDelete = new ArrayList<>();
+      URI nonExistentFile1 = new Path(baseURI.getPath(), "nonExistent1.txt").toUri();
+      URI nonExistentFile2 = new Path(baseURI.getPath(), "nonExistent2.txt").toUri();
+      urisToDelete.add(nonExistentFile1);
+      urisToDelete.add(nonExistentFile2);
+
+      // Should return true and skip non-existent files
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, false));
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithMixedExistingAndNonExisting()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchWithMixedFiles");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create some files
+      URI existingFile1 = new Path(baseURI.getPath(), "existing1.txt").toUri();
+      URI existingFile2 = new Path(baseURI.getPath(), "existing2.txt").toUri();
+      hadoopFS.touch(existingFile1);
+      hadoopFS.touch(existingFile2);
+
+      // Create list with mix of existing and non-existing files
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(existingFile1);
+      urisToDelete.add(new Path(baseURI.getPath(), "nonExistent.txt").toUri());
+      urisToDelete.add(existingFile2);
+
+      // Should successfully delete existing files and skip non-existing
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, false));
+
+      // Verify existing files are deleted
+      Assert.assertFalse(hadoopFS.exists(existingFile1));
+      Assert.assertFalse(hadoopFS.exists(existingFile2));
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithEmptyDirectory()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchWithEmptyDirectory");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create an empty directory
+      URI emptyDir = new Path(baseURI.getPath(), "emptyDir").toUri();
+      hadoopFS.mkdir(emptyDir);
+      Assert.assertTrue(hadoopFS.exists(emptyDir));
+
+      // Delete empty directory with forceDelete=false
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(emptyDir);
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, false));
+
+      // Verify directory is deleted
+      Assert.assertFalse(hadoopFS.exists(emptyDir));
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithNonEmptyDirectoryForceDeleteFalse()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchNonEmptyDirNoForce");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create a non-empty directory
+      URI nonEmptyDir = new Path(baseURI.getPath(), "nonEmptyDir").toUri();
+      hadoopFS.mkdir(nonEmptyDir);
+      URI fileInDir = new Path(nonEmptyDir.getPath(), "file.txt").toUri();
+      hadoopFS.touch(fileInDir);
+
+      // Try to delete non-empty directory with forceDelete=false
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(nonEmptyDir);
+      Assert.assertFalse(hadoopFS.deleteBatch(urisToDelete, false));
+
+      // Verify directory still exists
+      Assert.assertTrue(hadoopFS.exists(nonEmptyDir));
+      Assert.assertTrue(hadoopFS.exists(fileInDir));
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithNonEmptyDirectoryForceDeleteTrue()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchNonEmptyDirForce");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create a non-empty directory with a file
+      URI nonEmptyDir = new Path(baseURI.getPath(), "nonEmptyDir").toUri();
+      hadoopFS.mkdir(nonEmptyDir);
+      URI fileInDir = new Path(nonEmptyDir.getPath(), "file.txt").toUri();
+      hadoopFS.touch(fileInDir);
+
+      // Delete non-empty directory with forceDelete=true
+      // Note: This tests that the method processes the directory
+      // The actual deletion behavior depends on Hadoop's delete implementation
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(nonEmptyDir);
+      hadoopFS.deleteBatch(urisToDelete, true);
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithMixedFilesAndDirectories()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchMixed");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create files and directories
+      URI file1 = new Path(baseURI.getPath(), "file1.txt").toUri();
+      hadoopFS.touch(file1);
+
+      URI emptyDir = new Path(baseURI.getPath(), "emptyDir").toUri();
+      hadoopFS.mkdir(emptyDir);
+
+      URI nonEmptyDir = new Path(baseURI.getPath(), "nonEmptyDir").toUri();
+      hadoopFS.mkdir(nonEmptyDir);
+      URI fileInNonEmptyDir = new Path(nonEmptyDir.getPath(), "file.txt").toUri();
+      hadoopFS.touch(fileInNonEmptyDir);
+
+      URI file2 = new Path(baseURI.getPath(), "file2.txt").toUri();
+      hadoopFS.touch(file2);
+
+      // Delete with forceDelete=true
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(file1);
+      urisToDelete.add(emptyDir);
+      urisToDelete.add(nonEmptyDir);
+      urisToDelete.add(file2);
+
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, true));
+
+      // Verify all are deleted
+      Assert.assertFalse(hadoopFS.exists(file1));
+      Assert.assertFalse(hadoopFS.exists(emptyDir));
+      Assert.assertFalse(hadoopFS.exists(nonEmptyDir));
+      Assert.assertFalse(hadoopFS.exists(fileInNonEmptyDir));
+      Assert.assertFalse(hadoopFS.exists(file2));
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchWithDeepNestedDirectories()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchDeepNested");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create deeply nested directory structure
+      URI level1 = new Path(baseURI.getPath(), "level1").toUri();
+      hadoopFS.mkdir(level1);
+      URI level2 = new Path(level1.getPath(), "level2").toUri();
+      hadoopFS.mkdir(level2);
+      URI deepFile = new Path(level2.getPath(), "deepFile.txt").toUri();
+      hadoopFS.touch(deepFile);
+
+      // Delete with forceDelete=true
+      // Note: This tests that the method processes nested directories
+      List<URI> urisToDelete = new ArrayList<>();
+      urisToDelete.add(level1);
+
+      hadoopFS.deleteBatch(urisToDelete, true);
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
+
+  @Test
+  public void testDeleteBatchPerformanceWithManyFiles()
+      throws IOException {
+    URI baseURI = URI.create(TMP_DIR + "/testDeleteBatchPerformance");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+      hadoopFS.mkdir(baseURI);
+
+      // Create many files
+      int fileCount = 50;
+      List<URI> urisToDelete = new ArrayList<>();
+      for (int i = 0; i < fileCount; i++) {
+        URI testFile = new Path(baseURI.getPath(), "file" + i + ".txt").toUri();
+        hadoopFS.touch(testFile);
+        urisToDelete.add(testFile);
+      }
+
+      // Delete all files using deleteBatch
+      long startTime = System.currentTimeMillis();
+      Assert.assertTrue(hadoopFS.deleteBatch(urisToDelete, false));
+      long batchTime = System.currentTimeMillis() - startTime;
+
+      // Verify all files are deleted
+      for (URI uri : urisToDelete) {
+        Assert.assertFalse(hadoopFS.exists(uri));
+      }
+
+      // Log performance (batch deletion should be reasonably fast)
+      Assert.assertTrue(batchTime < 10000, "Batch deletion took too long: " + batchTime + "ms");
+
+      hadoopFS.delete(baseURI, true);
+    }
+  }
 }

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.inputformat.clplog;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -99,8 +98,9 @@ public class CLPLogMessageDecoder implements StreamMessageDecoder<byte[]> {
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
     try {
-      JsonNode jsonNode = JsonUtils.bytesToJsonNode(payload, offset, length);
-      return _recordExtractor.extract(JsonUtils.jsonNodeToMap(jsonNode), destination);
+      // Parse directly to Map, avoiding intermediate JsonNode representation for better performance
+      Map<String, Object> jsonMap = JsonUtils.bytesToMap(payload, offset, length);
+      return _recordExtractor.extract(jsonMap, destination);
     } catch (Exception e) {
       if (_errorSamplingPeriod != 0) {
         _numErrorsUntilNextPrint--;

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.inputformat.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -59,8 +58,9 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
     try {
-      JsonNode message = JsonUtils.bytesToJsonNode(payload, offset, length);
-      return _jsonRecordExtractor.extract(JsonUtils.jsonNodeToMap(message), destination);
+      // Parse directly to Map, avoiding intermediate JsonNode representation for better performance
+      Map<String, Object> jsonMap = JsonUtils.bytesToMap(payload, offset, length);
+      return _jsonRecordExtractor.extract(jsonMap, destination);
     } catch (Exception e) {
       throw new RuntimeException(
           "Caught exception while decoding JSON record with payload: " + new String(payload, offset, length), e);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
@@ -375,7 +375,7 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     SegmentSelectionResult result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(
         RAW_TABLE_NAME + "_REALTIME", taskConfigs, candidateSegmentsMap,
-        validDocIdsMetadata, alreadyMergedSegments);
+        validDocIdsMetadata, alreadyMergedSegments, null);
 
     Assert.assertNotNull(result);
     Assert.assertNotNull(result.getSegmentsForCompactMergeByPartition());
@@ -413,7 +413,7 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     SegmentSelectionResult result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(
         RAW_TABLE_NAME + "_REALTIME", taskConfigs, candidateSegmentsMap,
-        validDocIdsMetadata, alreadyMergedSegments);
+        validDocIdsMetadata, alreadyMergedSegments, null);
 
     Assert.assertNotNull(result);
     Assert.assertEquals(result.getSegmentsForDeletion().size(), 1, "Should have one segment for deletion");

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -60,7 +60,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>javacc-maven-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>javacc-m3ql</id>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/TransformNullPlanNode.java
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/src/main/java/org/apache/pinot/tsdb/m3ql/plan/TransformNullPlanNode.java
@@ -54,7 +54,7 @@ public class TransformNullPlanNode extends BaseTimeSeriesPlanNode {
 
   @Override
   public String getExplainName() {
-    return "TRANSFORM_NULL";
+    return "TRANSFORM_NULL(defaultValue=" + _defaultValue + ")";
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -230,7 +230,8 @@ public class QueryEnvironment {
           workerManager.getInstanceId(), sqlNodeAndOptions.getOptions(),
           _envConfig.defaultUseLiteMode(), _envConfig.defaultRunInBroker(), _envConfig.defaultUseBrokerPruning(),
           _envConfig.defaultLiteModeLeafStageLimit(), _envConfig.defaultHashFunction(),
-          _envConfig.defaultLiteModeLeafStageFanOutAdjustedLimit(), _envConfig.defaultLiteModeEnableJoins());
+          _envConfig.defaultLiteModeLeafStageFanOutAdjustedLimit(), _envConfig.defaultLiteModeEnableJoins(),
+          _multiClusterRoutingContext);
     }
     return new PlannerContext(_config, _catalogReader, _typeFactory, optProgram, traitProgram,
         sqlNodeAndOptions.getOptions(), _envConfig, format, physicalPlannerContext);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PhysicalPlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PhysicalPlannerContext.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.physical.v2.DistHashFunction;
@@ -71,6 +72,8 @@ public class PhysicalPlannerContext {
   private final int _liteModeLeafStageFanOutAdjustedLimit;
   private final DistHashFunction _defaultHashFunction;
   private final boolean _liteModeJoinsEnabled;
+  @Nullable
+  private final MultiClusterRoutingContext _multiClusterRoutingContext;
 
   /**
    * Used by controller when it needs to extract table names from the query.
@@ -90,6 +93,7 @@ public class PhysicalPlannerContext {
     _liteModeLeafStageFanOutAdjustedLimit = CommonConstants.Broker.DEFAULT_LITE_MODE_LEAF_STAGE_FAN_OUT_ADJUSTED_LIMIT;
     _defaultHashFunction = DistHashFunction.valueOf(KeySelector.DEFAULT_HASH_ALGORITHM.toUpperCase());
     _liteModeJoinsEnabled = CommonConstants.Broker.DEFAULT_LITE_MODE_ENABLE_JOINS;
+    _multiClusterRoutingContext = null;
   }
 
   public PhysicalPlannerContext(RoutingManager routingManager, String hostName, int port, long requestId,
@@ -98,13 +102,14 @@ public class PhysicalPlannerContext {
         CommonConstants.Broker.DEFAULT_USE_LITE_MODE, CommonConstants.Broker.DEFAULT_RUN_IN_BROKER,
         CommonConstants.Broker.DEFAULT_USE_BROKER_PRUNING, CommonConstants.Broker.DEFAULT_LITE_MODE_LEAF_STAGE_LIMIT,
         KeySelector.DEFAULT_HASH_ALGORITHM, CommonConstants.Broker.DEFAULT_LITE_MODE_LEAF_STAGE_FAN_OUT_ADJUSTED_LIMIT,
-        CommonConstants.Broker.DEFAULT_LITE_MODE_ENABLE_JOINS);
+        CommonConstants.Broker.DEFAULT_LITE_MODE_ENABLE_JOINS, null);
   }
 
   public PhysicalPlannerContext(RoutingManager routingManager, String hostName, int port, long requestId,
       String instanceId, Map<String, String> queryOptions, boolean defaultUseLiteMode, boolean defaultRunInBroker,
       boolean defaultUseBrokerPruning, int defaultLiteModeLeafStageLimit, String defaultHashFunction,
-      int defaultLiteModeLeafStageFanOutAdjustedLimit, boolean defaultLiteModeEnableJoins) {
+      int defaultLiteModeLeafStageFanOutAdjustedLimit, boolean defaultLiteModeEnableJoins,
+      @Nullable MultiClusterRoutingContext multiClusterRoutingContext) {
     _routingManager = routingManager;
     _hostName = hostName;
     _port = port;
@@ -121,6 +126,7 @@ public class PhysicalPlannerContext {
     _defaultHashFunction = DistHashFunction.valueOf(defaultHashFunction.toUpperCase());
     _instanceIdToQueryServerInstance.put(instanceId, getBrokerQueryServerInstance());
     _liteModeJoinsEnabled = defaultLiteModeEnableJoins;
+    _multiClusterRoutingContext = multiClusterRoutingContext;
   }
 
   public Supplier<Integer> getNodeIdGenerator() {
@@ -200,6 +206,11 @@ public class PhysicalPlannerContext {
 
   public DistHashFunction getDefaultHashFunction() {
     return _defaultHashFunction;
+  }
+
+  @Nullable
+  public MultiClusterRoutingContext getMultiClusterRoutingContext() {
+    return _multiClusterRoutingContext;
   }
 
   private QueryServerInstance getBrokerQueryServerInstance() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PlanFragmentAndMailboxAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PlanFragmentAndMailboxAssignment.java
@@ -156,7 +156,16 @@ public class PlanFragmentAndMailboxAssignment {
           tableScanMetadata.getUnavailableSegmentsMap().get(tableName));
     }
     fragmentMetadata.addScannedTable(tableName);
-    fragmentMetadata.setWorkerIdToSegmentsMap(tableScanMetadata.getWorkedIdToSegmentsMap());
+
+    // Handle logical tables vs physical tables differently
+    if (tableScanMetadata.isLogicalTable()) {
+      // For logical tables, use workerIdToTableSegmentsMap (physicalTableName -> segments)
+      fragmentMetadata.setWorkerIdToTableSegmentsMap(tableScanMetadata.getWorkerIdToLogicalTableSegmentsMap());
+    } else {
+      // For physical tables, use workerIdToSegmentsMap (tableType -> segments)
+      fragmentMetadata.setWorkerIdToSegmentsMap(tableScanMetadata.getWorkedIdToSegmentsMap());
+    }
+
     NodeHint nodeHint = NodeHint.fromRelHints(tableScan.getHints());
     fragmentMetadata.setTableOptions(nodeHint.getHintOptions().get(PinotHintOptions.TABLE_HINT_OPTIONS));
     if (tableScanMetadata.getTimeBoundaryInfo() != null) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/TableScanMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/TableScanMetadata.java
@@ -33,7 +33,7 @@ public class TableScanMetadata {
   private final Set<String> _scannedTables;
   /**
    * Stores workerId, which is an integer, to the segment mapping. The segment mapping is a map from table-type to list
-   * of segments.
+   * of segments. Used for physical tables.
    * <pre>
    *   {
    *     0: {
@@ -47,27 +47,81 @@ public class TableScanMetadata {
    * </pre>
    */
   private final Map<Integer, Map<String, List<String>>> _workedIdToSegmentsMap;
+  /**
+   * Stores workerId to the segment mapping for logical tables. The segment mapping is a map from
+   * physical table name (with type suffix) to list of segments. Used for logical tables.
+   * <pre>
+   *   {
+   *     0: {
+   *       "orders_OFFLINE": ["segment1", "segment2"],
+   *       "orders_REALTIME": ["segment3"],
+   *       "orders_archive_OFFLINE": ["segment4"]
+   *     },
+   *     1: {
+   *       ...
+   *     }
+   *   }
+   * </pre>
+   */
+  @Nullable
+  private final Map<Integer, Map<String, List<String>>> _workerIdToLogicalTableSegmentsMap;
   private final Map<String, String> _tableOptions;
   private final Map<String, Set<String>> _unavailableSegmentsMap;
   @Nullable
   private final TimeBoundaryInfo _timeBoundaryInfo;
+  /**
+   * Indicates whether this is a logical table scan.
+   */
+  private final boolean _isLogicalTable;
 
+  /**
+   * Constructor for physical table scan metadata.
+   */
   public TableScanMetadata(Set<String> scannedTables, Map<Integer, Map<String, List<String>>> workedIdToSegmentsMap,
       Map<String, String> tableOptions, Map<String, Set<String>> unavailableSegmentsMap,
       @Nullable TimeBoundaryInfo timeBoundaryInfo) {
     _scannedTables = scannedTables;
     _workedIdToSegmentsMap = workedIdToSegmentsMap;
+    _workerIdToLogicalTableSegmentsMap = null;
     _tableOptions = tableOptions;
     _unavailableSegmentsMap = unavailableSegmentsMap;
     _timeBoundaryInfo = timeBoundaryInfo;
+    _isLogicalTable = false;
+  }
+
+  /**
+   * Constructor for logical table scan metadata.
+   */
+  public TableScanMetadata(Set<String> scannedTables,
+      Map<Integer, Map<String, List<String>>> workerIdToLogicalTableSegmentsMap,
+      Map<String, String> tableOptions, Map<String, Set<String>> unavailableSegmentsMap,
+      @Nullable TimeBoundaryInfo timeBoundaryInfo, boolean isLogicalTable) {
+    _scannedTables = scannedTables;
+    if (isLogicalTable) {
+      _workedIdToSegmentsMap = null;
+      _workerIdToLogicalTableSegmentsMap = workerIdToLogicalTableSegmentsMap;
+    } else {
+      _workedIdToSegmentsMap = workerIdToLogicalTableSegmentsMap;
+      _workerIdToLogicalTableSegmentsMap = null;
+    }
+    _tableOptions = tableOptions;
+    _unavailableSegmentsMap = unavailableSegmentsMap;
+    _timeBoundaryInfo = timeBoundaryInfo;
+    _isLogicalTable = isLogicalTable;
   }
 
   public Set<String> getScannedTables() {
     return _scannedTables;
   }
 
+  @Nullable
   public Map<Integer, Map<String, List<String>>> getWorkedIdToSegmentsMap() {
     return _workedIdToSegmentsMap;
+  }
+
+  @Nullable
+  public Map<Integer, Map<String, List<String>>> getWorkerIdToLogicalTableSegmentsMap() {
+    return _workerIdToLogicalTableSegmentsMap;
   }
 
   public Map<String, String> getTableOptions() {
@@ -81,5 +135,9 @@ public class TableScanMetadata {
   @Nullable
   public TimeBoundaryInfo getTimeBoundaryInfo() {
     return _timeBoundaryInfo;
+  }
+
+  public boolean isLogicalTable() {
+    return _isLogicalTable;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -584,7 +584,9 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
     Map<String, String> tableOptions = getTableOptions(tableScan.getHints());
 
     // Step 1: Get LogicalTableRouteInfo using LogicalTableRouteProvider
-    LogicalTableRouteProvider tableRouteProvider = new LogicalTableRouteProvider();
+    // Use MultiClusterRoutingContext if available to support logical tables with physical tables from remote clusters
+    LogicalTableRouteProvider tableRouteProvider =
+        new LogicalTableRouteProvider(_physicalPlannerContext.getMultiClusterRoutingContext());
     LogicalTableRouteInfo logicalTableRouteInfo = new LogicalTableRouteInfo();
     tableRouteProvider.fillTableConfigMetadata(logicalTableRouteInfo, logicalTableName, _tableCache);
     tableRouteProvider.fillRouteMetadata(logicalTableRouteInfo, _routingManager);

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/validation/LiteModeJoinValidationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/validation/LiteModeJoinValidationTest.java
@@ -49,7 +49,8 @@ public class LiteModeJoinValidationTest {
         CommonConstants.Broker.DEFAULT_LITE_MODE_LEAF_STAGE_LIMIT,
         KeySelector.DEFAULT_HASH_ALGORITHM,
         CommonConstants.Broker.DEFAULT_LITE_MODE_LEAF_STAGE_FAN_OUT_ADJUSTED_LIMIT,
-        liteModeJoinsEnabled);
+        liteModeJoinsEnabled,
+        null);
   }
 
   private static PRelNode makeJoinPlan() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelManager.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelManager.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.query.mailbox.channel;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -51,22 +52,30 @@ public class ChannelManager {
    */
   private final Duration _idleTimeout;
   private final int _maxInboundMessageSize;
+  /**
+   * Buffer allocator configured to prefer direct (off-heap) buffers for better performance.
+   * Using a single allocator instance across all channels allows for better memory pooling and reduces fragmentation.
+   */
+  private final PooledByteBufAllocator _bufAllocator;
 
   public ChannelManager(@Nullable TlsConfig tlsConfig, int maxInboundMessageSize, Duration idleTimeout) {
     _tlsConfig = tlsConfig;
     _maxInboundMessageSize = maxInboundMessageSize;
     _idleTimeout = idleTimeout;
+    // Use direct buffers (off-heap) for better performance - matches server-side configuration
+    _bufAllocator = new PooledByteBufAllocator(true);
   }
 
   public ManagedChannel getChannel(String hostname, int port) {
-    // TODO: Revisit parameters
+    // Always use NettyChannelBuilder to allow setting Netty-specific channel options like the buffer allocator.
+    // This ensures we can explicitly configure direct (off-heap) buffers for better performance.
     if (_tlsConfig != null) {
       return _channelMap.computeIfAbsent(Pair.of(hostname, port),
           (k) -> {
             NettyChannelBuilder channelBuilder = NettyChannelBuilder
                 .forAddress(k.getLeft(), k.getRight())
-                .maxInboundMessageSize(
-                    _maxInboundMessageSize)
+                .maxInboundMessageSize(_maxInboundMessageSize)
+                .withOption(ChannelOption.ALLOCATOR, _bufAllocator)
                 .sslContext(ServerGrpcQueryClient.buildSslContext(_tlsConfig));
             return decorate(channelBuilder).build();
           }
@@ -74,17 +83,17 @@ public class ChannelManager {
     } else {
       return _channelMap.computeIfAbsent(Pair.of(hostname, port),
           (k) -> {
-            ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder
+            NettyChannelBuilder channelBuilder = NettyChannelBuilder
                 .forAddress(k.getLeft(), k.getRight())
-                .maxInboundMessageSize(
-                    _maxInboundMessageSize)
+                .maxInboundMessageSize(_maxInboundMessageSize)
+                .withOption(ChannelOption.ALLOCATOR, _bufAllocator)
                 .usePlaintext();
             return decorate(channelBuilder).build();
           });
     }
   }
 
-  private ManagedChannelBuilder<?> decorate(ManagedChannelBuilder<?> builder) {
+  private NettyChannelBuilder decorate(NettyChannelBuilder builder) {
     return builder.idleTimeout(_idleTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -256,7 +256,7 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -330,7 +330,7 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -121,7 +121,7 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/ErrorOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/ErrorOperator.java
@@ -98,7 +98,7 @@ public class ErrorOperator extends MultiStageOperator {
     return _childOperators;
   }
 
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<LiteralValueOperator.StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -119,7 +119,7 @@ public class FilterOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -262,7 +262,7 @@ public class LeafOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -100,7 +100,7 @@ public class LiteralValueOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LookupJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LookupJoinOperator.java
@@ -145,7 +145,7 @@ public class LookupJoinOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -275,7 +275,7 @@ public class MailboxSendOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -177,7 +177,7 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
         .orElse(MultiStageQueryStats.emptyStats(_context.getStageId()));
   }
 
-  protected abstract StatMap<?> copyStatMaps();
+  public abstract StatMap<?> copyStatMaps();
 
   // TODO: Ideally close() call should finish within request deadline.
   // TODO: Consider passing deadline as part of the API.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -133,7 +133,7 @@ public class SortOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -115,7 +115,7 @@ public class TransformOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/UnnestOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/UnnestOperator.java
@@ -266,7 +266,7 @@ public class UnnestOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -283,7 +283,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/SetOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/set/SetOperator.java
@@ -56,7 +56,7 @@ public abstract class SetOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerOperator.java
@@ -148,7 +148,7 @@ public class PipelineBreakerOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -20,8 +20,9 @@ package org.apache.pinot.query.service.dispatch;
 
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
 import java.util.function.Consumer;
@@ -41,16 +42,27 @@ import org.apache.pinot.query.routing.QueryServerInstance;
  */
 class DispatchClient {
   private static final StreamObserver<Worker.CancelResponse> NO_OP_CANCEL_STREAM_OBSERVER = new CancelObserver();
+  /**
+   * Shared buffer allocator configured to prefer direct (off-heap) buffers for better performance.
+   * Using a static allocator allows for better memory pooling across all DispatchClient instances.
+   */
+  private static final PooledByteBufAllocator BUF_ALLOCATOR = new PooledByteBufAllocator(true);
 
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
   public DispatchClient(String host, int port, @Nullable TlsConfig tlsConfig) {
+    // Always use NettyChannelBuilder to allow setting Netty-specific channel options like the buffer allocator.
+    // This ensures we can explicitly configure direct (off-heap) buffers for better performance.
     if (tlsConfig == null) {
-      _channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+      _channel = NettyChannelBuilder.forAddress(host, port)
+          .usePlaintext()
+          .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR)
+          .build();
     } else {
       _channel = NettyChannelBuilder.forAddress(host, port)
           .sslContext(ServerGrpcQueryClient.buildSslContext(tlsConfig))
+          .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR)
           .build();
     }
     _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -255,9 +255,8 @@ public class QueryDispatcher {
   public FailureDetector.ServerState checkConnectivityToInstance(ServerInstance serverInstance) {
     String hostname = serverInstance.getHostname();
     int port = serverInstance.getQueryServicePort();
-    String hostnamePort = String.format("%s_%d", hostname, port);
 
-    DispatchClient client = _dispatchClientMap.get(hostnamePort);
+    DispatchClient client = _dispatchClientMap.get(toHostnamePortKey(hostname, port));
     // Could occur if the cluster is only serving single-stage queries
     if (client == null) {
       LOGGER.debug("No DispatchClient found for server with instanceId: {}", serverInstance.getInstanceId());
@@ -510,8 +509,27 @@ public class QueryDispatcher {
   private DispatchClient getOrCreateDispatchClient(QueryServerInstance queryServerInstance) {
     String hostname = queryServerInstance.getHostname();
     int port = queryServerInstance.getQueryServicePort();
-    String hostnamePort = String.format("%s_%d", hostname, port);
-    return _dispatchClientMap.computeIfAbsent(hostnamePort, k -> new DispatchClient(hostname, port, _tlsConfig));
+    return _dispatchClientMap.computeIfAbsent(toHostnamePortKey(hostname, port),
+        k -> new DispatchClient(hostname, port, _tlsConfig));
+  }
+
+  /**
+   * Reset the connection backoff for a server. When the GRPC channel enters a TRANSIENT_FAILURE state from
+   * connection failures, it will fast fail requests and reconnect with exponential backoff. This method
+   * resets the backoff so servers that have recovered can be reconnected to immediately.
+   */
+  public void resetClientConnectionBackoff(ServerInstance serverInstance) {
+    String hostname = serverInstance.getHostname();
+    int port = serverInstance.getQueryServicePort();
+    DispatchClient dispatchClient = _dispatchClientMap.get(toHostnamePortKey(hostname, port));
+    if (dispatchClient != null) {
+      LOGGER.info("Resetting connection backoff for server: {}", serverInstance.getInstanceId());
+      dispatchClient.getChannel().resetConnectBackoff();
+    }
+  }
+
+  private static String toHostnamePortKey(String hostname, int port) {
+    return String.format("%s_%d", hostname, port);
   }
 
   /// Concatenates the results of the sub-plan and returns a [QueryResult] with the concatenated result.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -81,10 +81,6 @@ import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.PlanNodeToOpChain;
-import org.apache.pinot.query.runtime.timeseries.PhysicalTimeSeriesBrokerPlanVisitor;
-import org.apache.pinot.query.runtime.timeseries.TimeSeriesExecutionContext;
-import org.apache.pinot.query.service.dispatch.timeseries.TimeSeriesDispatchClient;
-import org.apache.pinot.query.service.dispatch.timeseries.TimeSeriesDispatchObserver;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.query.QueryExecutionContext;
@@ -94,13 +90,6 @@ import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.PlanVersions;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Request.MetadataKeys;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Response.ServerResponseStatus;
-import org.apache.pinot.tsdb.planner.TimeSeriesExchangeNode;
-import org.apache.pinot.tsdb.planner.physical.TimeSeriesDispatchablePlan;
-import org.apache.pinot.tsdb.planner.physical.TimeSeriesQueryServerInstance;
-import org.apache.pinot.tsdb.spi.TimeBuckets;
-import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
-import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
-import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,24 +104,12 @@ public class QueryDispatcher {
   private final MailboxService _mailboxService;
   private final ExecutorService _executorService;
   private final Map<String, DispatchClient> _dispatchClientMap = new ConcurrentHashMap<>();
-  private final Map<String, TimeSeriesDispatchClient> _timeSeriesDispatchClientMap = new ConcurrentHashMap<>();
   @Nullable
   private final TlsConfig _tlsConfig;
   // maps broker-generated query id to the set of servers that the query was dispatched to
   private final Map<Long, Set<QueryServerInstance>> _serversByQuery;
-  private final PhysicalTimeSeriesBrokerPlanVisitor _timeSeriesBrokerPlanVisitor =
-      new PhysicalTimeSeriesBrokerPlanVisitor();
   private final FailureDetector _failureDetector;
   private final Duration _cancelTimeout;
-
-  public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector) {
-    this(mailboxService, failureDetector, null, false);
-  }
-
-  public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
-      boolean enableCancellation) {
-    this(mailboxService, failureDetector, tlsConfig, enableCancellation, Duration.ofSeconds(1));
-  }
 
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout) {
@@ -383,24 +360,6 @@ public class QueryDispatcher {
     }
   }
 
-  Map<String, String> initializeTimeSeriesMetadataMap(TimeSeriesDispatchablePlan dispatchablePlan, long deadlineMs,
-      RequestContext requestContext, String instanceId) {
-    Map<String, String> result = new HashMap<>();
-    TimeBuckets timeBuckets = dispatchablePlan.getTimeBuckets();
-    result.put(MetadataKeys.TimeSeries.LANGUAGE, dispatchablePlan.getLanguage());
-    result.put(MetadataKeys.TimeSeries.START_TIME_SECONDS, Long.toString(timeBuckets.getTimeBuckets()[0]));
-    result.put(MetadataKeys.TimeSeries.WINDOW_SECONDS, Long.toString(timeBuckets.getBucketSize().getSeconds()));
-    result.put(MetadataKeys.TimeSeries.NUM_ELEMENTS, Long.toString(timeBuckets.getTimeBuckets().length));
-    result.put(MetadataKeys.TimeSeries.DEADLINE_MS, Long.toString(deadlineMs));
-    Map<String, List<String>> leafIdToSegments = dispatchablePlan.getLeafIdToSegmentsByInstanceId().get(instanceId);
-    for (Map.Entry<String, List<String>> entry : leafIdToSegments.entrySet()) {
-      result.put(MetadataKeys.TimeSeries.encodeSegmentListKey(entry.getKey()), String.join(",", entry.getValue()));
-    }
-    result.put(MetadataKeys.REQUEST_ID, Long.toString(requestContext.getRequestId()));
-    result.put(MetadataKeys.BROKER_ID, requestContext.getBrokerId());
-    return result;
-  }
-
   private static Worker.QueryRequest createRequest(QueryServerInstance serverInstance,
       Map<DispatchablePlanFragment, StageInfo> stageInfos, ByteString protoRequestMetadata) {
     Worker.QueryRequest.Builder requestBuilder = Worker.QueryRequest.newBuilder();
@@ -555,14 +514,6 @@ public class QueryDispatcher {
     return _dispatchClientMap.computeIfAbsent(hostnamePort, k -> new DispatchClient(hostname, port, _tlsConfig));
   }
 
-  private TimeSeriesDispatchClient getOrCreateTimeSeriesDispatchClient(
-      TimeSeriesQueryServerInstance queryServerInstance) {
-    String hostname = queryServerInstance.getHostname();
-    int port = queryServerInstance.getQueryServicePort();
-    String key = String.format("%s_%d", hostname, port);
-    return _timeSeriesDispatchClientMap.computeIfAbsent(key, k -> new TimeSeriesDispatchClient(hostname, port));
-  }
-
   /// Concatenates the results of the sub-plan and returns a [QueryResult] with the concatenated result.
   /// [QueryThreadContext] must already be set up before calling this method.
   @VisibleForTesting
@@ -676,47 +627,6 @@ public class QueryDispatcher {
     _dispatchClientMap.clear();
     _mailboxService.shutdown();
     _executorService.shutdown();
-  }
-
-  public TimeSeriesBlock submitAndGet(long requestId, TimeSeriesDispatchablePlan plan, long timeoutMs,
-      RequestContext requestContext)
-      throws Exception {
-    long deadlineMs = System.currentTimeMillis() + timeoutMs;
-    BaseTimeSeriesPlanNode brokerFragment = plan.getBrokerFragment();
-    // Get consumers for leafs
-    Map<String, BlockingQueue<Object>> receiversByPlanId = new HashMap<>();
-    populateConsumers(brokerFragment, receiversByPlanId);
-    // Compile brokerFragment to get operators
-    TimeSeriesExecutionContext brokerExecutionContext =
-        new TimeSeriesExecutionContext(plan.getLanguage(), plan.getTimeBuckets(), deadlineMs, Map.of(), Map.of(),
-            receiversByPlanId);
-    BaseTimeSeriesOperator brokerOperator = _timeSeriesBrokerPlanVisitor.compile(brokerFragment, brokerExecutionContext,
-        plan.getNumInputServersForExchangePlanNode());
-    // Create dispatch observer for each query server
-    for (TimeSeriesQueryServerInstance serverInstance : plan.getQueryServerInstances()) {
-      String serverId = serverInstance.getInstanceId();
-      Deadline deadline = Deadline.after(deadlineMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-      Preconditions.checkState(!deadline.isExpired(), "Deadline expired before query could be sent to servers");
-      // Send server fragment to every server
-      Worker.TimeSeriesQueryRequest request = Worker.TimeSeriesQueryRequest.newBuilder()
-          .addAllDispatchPlan(plan.getSerializedServerFragments())
-          .putAllMetadata(initializeTimeSeriesMetadataMap(plan, deadlineMs, requestContext, serverId))
-          .putMetadata(MetadataKeys.REQUEST_ID, Long.toString(requestId))
-          .build();
-      TimeSeriesDispatchObserver dispatchObserver = new TimeSeriesDispatchObserver(receiversByPlanId);
-      getOrCreateTimeSeriesDispatchClient(serverInstance).submit(request, deadline, dispatchObserver);
-    }
-    // Execute broker fragment
-    return brokerOperator.nextBlock();
-  }
-
-  private void populateConsumers(BaseTimeSeriesPlanNode planNode, Map<String, BlockingQueue<Object>> receiverMap) {
-    if (planNode instanceof TimeSeriesExchangeNode) {
-      receiverMap.put(planNode.getId(), new ArrayBlockingQueue<>(TimeSeriesDispatchObserver.MAX_QUEUE_CAPACITY));
-    }
-    for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
-      populateConsumers(childNode, receiverMap);
-    }
   }
 
   public static class QueryResult {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesQueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/timeseries/TimeSeriesQueryDispatcher.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch.timeseries;
+
+import com.google.common.base.Preconditions;
+import io.grpc.Deadline;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.query.runtime.timeseries.PhysicalTimeSeriesBrokerPlanVisitor;
+import org.apache.pinot.query.runtime.timeseries.TimeSeriesExecutionContext;
+import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.utils.CommonConstants.Query.Request.MetadataKeys;
+import org.apache.pinot.tsdb.planner.TimeSeriesExchangeNode;
+import org.apache.pinot.tsdb.planner.physical.TimeSeriesDispatchablePlan;
+import org.apache.pinot.tsdb.planner.physical.TimeSeriesQueryServerInstance;
+import org.apache.pinot.tsdb.spi.TimeBuckets;
+import org.apache.pinot.tsdb.spi.operator.BaseTimeSeriesOperator;
+import org.apache.pinot.tsdb.spi.plan.BaseTimeSeriesPlanNode;
+import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
+
+
+/// Query dispatcher for time-series queries.
+public class TimeSeriesQueryDispatcher {
+  private final PhysicalTimeSeriesBrokerPlanVisitor _planVisitor = new PhysicalTimeSeriesBrokerPlanVisitor();
+  private final Map<String, TimeSeriesDispatchClient> _dispatchClientMap = new ConcurrentHashMap<>();
+
+  public void start() {
+    // No-op by default.
+  }
+
+  public void shutdown() {
+    for (TimeSeriesDispatchClient dispatchClient : _dispatchClientMap.values()) {
+      dispatchClient.getChannel().shutdown();
+    }
+    _dispatchClientMap.clear();
+  }
+
+  /// Submits a time-series dispatchable plan to servers and returns the broker-side result block.
+  public TimeSeriesBlock submitAndGet(long requestId, TimeSeriesDispatchablePlan plan, long timeoutMs,
+      RequestContext requestContext) {
+    long deadlineMs = System.currentTimeMillis() + timeoutMs;
+    BaseTimeSeriesPlanNode brokerFragment = plan.getBrokerFragment();
+    Map<String, BlockingQueue<Object>> receiversByPlanId = new HashMap<>();
+    populateConsumers(brokerFragment, receiversByPlanId);
+    TimeSeriesExecutionContext brokerExecutionContext =
+        new TimeSeriesExecutionContext(plan.getLanguage(), plan.getTimeBuckets(), deadlineMs, Map.of(), Map.of(),
+            receiversByPlanId);
+    BaseTimeSeriesOperator brokerOperator =
+        _planVisitor.compile(brokerFragment, brokerExecutionContext, plan.getNumInputServersForExchangePlanNode());
+    for (TimeSeriesQueryServerInstance serverInstance : plan.getQueryServerInstances()) {
+      String serverId = serverInstance.getInstanceId();
+      Deadline deadline = Deadline.after(deadlineMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      Preconditions.checkState(!deadline.isExpired(), "Deadline expired before query could be sent to servers");
+      Worker.TimeSeriesQueryRequest request = Worker.TimeSeriesQueryRequest.newBuilder()
+          .addAllDispatchPlan(plan.getSerializedServerFragments())
+          .putAllMetadata(initializeTimeSeriesMetadataMap(plan, deadlineMs, requestContext, serverId))
+          .putMetadata(MetadataKeys.REQUEST_ID, Long.toString(requestId))
+          .build();
+      TimeSeriesDispatchObserver dispatchObserver = new TimeSeriesDispatchObserver(receiversByPlanId);
+      getOrCreateTimeSeriesDispatchClient(serverInstance).submit(request, deadline, dispatchObserver);
+    }
+    return brokerOperator.nextBlock();
+  }
+
+  private void populateConsumers(BaseTimeSeriesPlanNode planNode, Map<String, BlockingQueue<Object>> receiverMap) {
+    if (planNode instanceof TimeSeriesExchangeNode) {
+      receiverMap.put(planNode.getId(), new ArrayBlockingQueue<>(TimeSeriesDispatchObserver.MAX_QUEUE_CAPACITY));
+    }
+    for (BaseTimeSeriesPlanNode childNode : planNode.getInputs()) {
+      populateConsumers(childNode, receiverMap);
+    }
+  }
+
+  private Map<String, String> initializeTimeSeriesMetadataMap(TimeSeriesDispatchablePlan dispatchablePlan,
+      long deadlineMs, RequestContext requestContext, String instanceId) {
+    Map<String, String> result = new HashMap<>();
+    TimeBuckets timeBuckets = dispatchablePlan.getTimeBuckets();
+    result.put(MetadataKeys.TimeSeries.LANGUAGE, dispatchablePlan.getLanguage());
+    result.put(MetadataKeys.TimeSeries.START_TIME_SECONDS, Long.toString(timeBuckets.getTimeBuckets()[0]));
+    result.put(MetadataKeys.TimeSeries.WINDOW_SECONDS, Long.toString(timeBuckets.getBucketSize().getSeconds()));
+    result.put(MetadataKeys.TimeSeries.NUM_ELEMENTS, Long.toString(timeBuckets.getTimeBuckets().length));
+    result.put(MetadataKeys.TimeSeries.DEADLINE_MS, Long.toString(deadlineMs));
+    Map<String, List<String>> leafIdToSegments = dispatchablePlan.getLeafIdToSegmentsByInstanceId().get(instanceId);
+    for (Map.Entry<String, List<String>> entry : leafIdToSegments.entrySet()) {
+      result.put(MetadataKeys.TimeSeries.encodeSegmentListKey(entry.getKey()), String.join(",", entry.getValue()));
+    }
+    result.put(MetadataKeys.REQUEST_ID, Long.toString(requestContext.getRequestId()));
+    result.put(MetadataKeys.BROKER_ID, requestContext.getBrokerId());
+    return result;
+  }
+
+  private TimeSeriesDispatchClient getOrCreateTimeSeriesDispatchClient(
+      TimeSeriesQueryServerInstance queryServerInstance) {
+    String hostname = queryServerInstance.getHostname();
+    int port = queryServerInstance.getQueryServicePort();
+    String key = hostname + "_" + port;
+    return _dispatchClientMap.computeIfAbsent(key, k -> new TimeSeriesDispatchClient(hostname, port));
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -24,12 +24,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
 import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
@@ -74,6 +76,7 @@ public class OpChainSchedulerServiceTest {
   public void beforeMethod() {
     _operatorA = Mockito.mock(MultiStageOperator.class);
     clearInvocations(_operatorA);
+    Mockito.when(_operatorA.copyStatMaps()).thenAnswer(inv -> new StatMap<>(MailboxSendOperator.StatKey.class));
   }
 
   private OpChain getChain(MultiStageOperator operator) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/BlockListMultiStageOperator.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/BlockListMultiStageOperator.java
@@ -84,7 +84,7 @@ public class BlockListMultiStageOperator extends MultiStageOperator {
   }
 
   @Override
-  protected StatMap<?> copyStatMaps() {
+  public StatMap<LiteralValueOperator.StatKey> copyStatMaps() {
     return new StatMap<>(_statMap);
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -186,7 +186,7 @@ public class OpChainTest {
     }
 
     @Override
-    protected StatMap<?> copyStatMaps() {
+    public StatMap<LiteralValueOperator.StatKey> copyStatMaps() {
       return new StatMap<>(_statMap);
     }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.service.dispatch;
 
 import io.grpc.stub.StreamObserver;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,7 +75,8 @@ public class QueryDispatcherTest extends QueryTestSet {
         QueryEnvironmentTestBase.TABLE_SCHEMAS, QueryEnvironmentTestBase.SERVER1_SEGMENTS,
         QueryEnvironmentTestBase.SERVER2_SEGMENTS, null);
     _queryDispatcher =
-        new QueryDispatcher(Mockito.mock(MailboxService.class), Mockito.mock(FailureDetector.class), null, true);
+        new QueryDispatcher(Mockito.mock(MailboxService.class), Mockito.mock(FailureDetector.class), null, true,
+            Duration.ofSeconds(1));
   }
 
   @AfterClass

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -740,6 +740,10 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
     return _segmentName;
   }
 
+  public int getTotalDocs() {
+    return _totalDocs;
+  }
+
   @Override
   public void seal()
       throws Exception {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnarDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnarDataSource.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
 import org.apache.pinot.spi.data.readers.ColumnarDataSource;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -32,12 +33,16 @@ public class PinotSegmentColumnarDataSource implements ColumnarDataSource {
 
   private final IndexSegment _indexSegment;
   private final int _totalDocs;
-  private final boolean _initializeDefaultValueReaders;
+  private final RoaringBitmap _validDocIds;
 
-  public PinotSegmentColumnarDataSource(IndexSegment indexSegment, boolean initializeDefaultValueReaders) {
+  /**
+   * @param indexSegment Source segment to read from
+   *
+   */
+  public PinotSegmentColumnarDataSource(IndexSegment indexSegment, RoaringBitmap validDocIds) {
     _indexSegment = indexSegment;
     _totalDocs = indexSegment.getSegmentMetadata().getTotalDocs();
-    _initializeDefaultValueReaders = initializeDefaultValueReaders;
+    _validDocIds = validDocIds;
   }
 
   @Override
@@ -47,13 +52,18 @@ public class PinotSegmentColumnarDataSource implements ColumnarDataSource {
 
   @Override
   public ColumnReaderFactory createColumnReaderFactory() {
-    return new PinotSegmentColumnReaderFactory(_indexSegment, _initializeDefaultValueReaders);
+    return new PinotSegmentColumnReaderFactory(_indexSegment, true, false);
+  }
+
+  @Override
+  public RoaringBitmap getValidDocIds() {
+    return _validDocIds;
   }
 
   @Override
   public void close()
       throws IOException {
-    // Segment lifecycle is managed externally, so no cleanup needed here
+    _indexSegment.destroy();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -268,18 +268,21 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
         oldSegment.getSegmentName());
     for (Map.Entry<Object, RecordLocation> obj : _previousKeyToRecordLocationMap.entrySet()) {
       IndexSegment prevSegment = obj.getValue().getSegment();
+      RecordLocation currentLocation = _primaryKeyToRecordLocationMap.get(obj.getKey());
       if (prevSegment != null) {
-        try (UpsertUtils.RecordInfoReader recordInfoReader = new UpsertUtils.RecordInfoReader(prevSegment,
-            _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn)) {
-          int newDocId = obj.getValue().getDocId();
-          int currentDocId = _primaryKeyToRecordLocationMap.get(obj.getKey()).getDocId();
-          RecordInfo recordInfo = recordInfoReader.getRecordInfo(newDocId);
-          replaceDocId(prevSegment, prevSegment.getValidDocIds(), prevSegment.getQueryableDocIds(), oldSegment,
-              currentDocId, newDocId, recordInfo);
-        } catch (IOException e) {
-          throw new RuntimeException(e);
+        if (currentLocation != null && currentLocation.getSegment() == oldSegment) {
+          try (UpsertUtils.RecordInfoReader recordInfoReader = new UpsertUtils.RecordInfoReader(prevSegment,
+              _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn)) {
+            int newDocId = obj.getValue().getDocId();
+            int currentDocId = _primaryKeyToRecordLocationMap.get(obj.getKey()).getDocId();
+            RecordInfo recordInfo = recordInfoReader.getRecordInfo(newDocId);
+            replaceDocId(prevSegment, prevSegment.getValidDocIds(), prevSegment.getQueryableDocIds(), oldSegment,
+                currentDocId, newDocId, recordInfo);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+          _primaryKeyToRecordLocationMap.put(obj.getKey(), obj.getValue());
         }
-        _primaryKeyToRecordLocationMap.put(obj.getKey(), obj.getValue());
       } else {
         _primaryKeyToRecordLocationMap.remove(obj.getKey());
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1604,11 +1604,22 @@ public final class TableConfigUtils {
     }
   }
 
-  public static boolean checkForInconsistentStateConfigs(TableConfig tableConfig) {
-    return tableConfig != null && tableConfig.getUpsertConfig() != null && tableConfig.getReplication() > 1 && (
-        tableConfig.getUpsertConfig().getMode() == UpsertConfig.Mode.PARTIAL || (
-            tableConfig.getUpsertConfig().isDropOutOfOrderRecord()
-                && tableConfig.getUpsertConfig().getConsistencyMode() == UpsertConfig.ConsistencyMode.NONE));
+  /**
+   * Checks if the table config has inconsistent state configurations that could cause
+   * data inconsistency during force commit/reload operations.
+   *
+   * @param tableConfig the table config to check, may be null
+   * @return true if the table has inconsistent state configs, false if tableConfig is null or no issues found
+   */
+  public static boolean checkForInconsistentStateConfigs(@Nullable TableConfig tableConfig) {
+    UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
+    if (upsertConfig == null) {
+      return false;
+    }
+    return tableConfig.getReplication() > 1 && (
+        upsertConfig.getMode() == UpsertConfig.Mode.PARTIAL
+            || (upsertConfig.isDropOutOfOrderRecord()
+            && upsertConfig.getConsistencyMode() == UpsertConfig.ConsistencyMode.NONE));
   }
 
   // enum of all the skip-able validation types.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1245,6 +1245,9 @@ public final class TableConfigUtils {
       for (FieldConfig fieldConfig : fieldConfigs) {
         String column = fieldConfig.getName();
         Preconditions.checkState(schema.hasColumn(column), "Failed to find column: %s in schema", column);
+
+        // Validate DELTA / DELTADELTA compression codecs compatibility
+        validateGorillaCompressionCodecIfPresent(fieldConfig, schema.getFieldSpecFor(column));
       }
       validateIndexingConfigAndFieldConfigListCompatibility(indexingConfig, fieldConfigs);
     }
@@ -1929,5 +1932,25 @@ public final class TableConfigUtils {
     Set<String> relevantTenants =
         getRelevantTags(tableConfig).stream().map(TagNameUtils::getTenantFromTag).collect(Collectors.toSet());
     return relevantTenants.contains(tenantName);
+  }
+
+  private static void validateGorillaCompressionCodecIfPresent(FieldConfig fieldConfig, FieldSpec fieldSpec) {
+    if (fieldConfig.getCompressionCodec() == null) {
+      return;
+    }
+    switch (fieldConfig.getCompressionCodec()) {
+      case DELTA:
+      case DELTADELTA:
+        Preconditions.checkState(fieldSpec.isSingleValueField(),
+            "Compression codec %s can only be used on single-value columns, found multi-value column: %s",
+            fieldConfig.getCompressionCodec(), fieldConfig.getName());
+        DataType storedType = fieldSpec.getDataType().getStoredType();
+        Preconditions.checkState(storedType == DataType.INT || storedType == DataType.LONG,
+            "Compression codec %s can only be used on INT/LONG data types, found %s for column: %s",
+            fieldConfig.getCompressionCodec(), storedType, fieldConfig.getName());
+        break;
+      default:
+        // no-op for other codecs
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1175,6 +1175,26 @@ public class TableConfigUtilsTest {
 
     try {
       FieldConfig fieldConfig =
+          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+    } catch (Exception e) {
+      assertEquals(e.getMessage(),
+          "Compression codec DELTADELTA can only be used on INT/LONG data types, found STRING for column: myCol1");
+    }
+
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+    } catch (Exception e) {
+      assertEquals(e.getMessage(),
+          "Compression codec DELTADELTA can only be used on single-value columns, found multi-value column: myCol2");
+    }
+
+    try {
+      FieldConfig fieldConfig =
           new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -81,6 +81,7 @@ import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager;
 import org.apache.pinot.core.data.manager.realtime.ServerRateLimitConfigChangeListener;
+import org.apache.pinot.core.data.manager.realtime.UpsertInconsistentStateConfig;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
@@ -275,6 +276,10 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(
         new ClusterConfigForTable.ConfigChangeListener());
     LOGGER.info("Registered ClusterConfigForTable change listener");
+    // Register configuration change listener for upsert force commit/reload disable setting
+    _clusterConfigChangeHandler.registerClusterConfigChangeListener(
+        UpsertInconsistentStateConfig.getInstance());
+    LOGGER.info("Registered UpsertInconsistentStateConfig change listener for dynamic force commit/reload control");
 
     LOGGER.info("Initializing Helix manager with zkAddress: {}, clusterName: {}, instanceId: {}", _zkAddress,
         _helixClusterName, _instanceId);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.server.starter.helix;
 
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -40,10 +42,16 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
 
   private final String _instanceId;
   private final InstanceDataManager _instanceDataManager;
+  /** Provides custom thread pools for executing Helix state transition messages. If this is null, all state
+   * transition message will be executed using the default shared thread pool by Helix */
+  @Nullable
+  private final StateTransitionThreadPoolManager _stateTransitionThreadPoolManager;
 
-  public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager) {
+  public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager,
+      @Nullable StateTransitionThreadPoolManager stateTransitionThreadPoolManager) {
     _instanceId = instanceId;
     _instanceDataManager = instanceDataManager;
+    _stateTransitionThreadPoolManager = stateTransitionThreadPoolManager;
   }
 
   public static String getStateModelName() {
@@ -162,7 +170,6 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     public void onBecomeOnlineFromOffline(Message message, NotificationContext context)
         throws Exception {
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeOnlineFromOffline() : {}", message);
-
       try {
         _instanceDataManager.addOnlineSegment(message.getResourceName(), message.getPartitionName());
       } catch (Exception e) {
@@ -246,5 +253,44 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         throw e;
       }
     }
+  }
+
+  /**
+   * Get thread pool to handle the given state transition message.
+   * If this method returns null, the threadpool returned from
+   * {@link StateModelFactory#getExecutorService(String resourceName, String fromState, String toState)} will be used;
+   * If this method returns null the threadpool returned from
+   * {@link StateModelFactory#getExecutorService(String resourceName)} will be used.
+   * If that method return null too, then the default shared threadpool will be used.
+   * This method may be called only once for each category of messages,
+   * it will NOT be called during each state transition.
+   * @param messageInfo contains information used to categorize messages to use different threadpools
+   * @return An object contains the MessageIdentifierBase and the assigned threadpool for the input message
+   */
+  @Override
+  @Nullable
+  public CustomizedExecutorService getExecutorService(Message.MessageInfo messageInfo) {
+    if (_stateTransitionThreadPoolManager == null) {
+      return super.getExecutorService(messageInfo);
+    }
+    return _stateTransitionThreadPoolManager.getExecutorService(messageInfo);
+  }
+
+  @Override
+  @Nullable
+  public ExecutorService getExecutorService(String resourceName, String fromState, String toState) {
+    if (_stateTransitionThreadPoolManager == null) {
+      return super.getExecutorService(resourceName, fromState, toState);
+    }
+    return _stateTransitionThreadPoolManager.getExecutorService(resourceName, fromState, toState);
+  }
+
+  @Override
+  @Nullable
+  public ExecutorService getExecutorService(String resourceName) {
+    if (_stateTransitionThreadPoolManager == null) {
+      return super.getExecutorService(resourceName);
+    }
+    return _stateTransitionThreadPoolManager.getExecutorService(resourceName);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/StateTransitionThreadPoolManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/StateTransitionThreadPoolManager.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter.helix;
+
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
+import org.apache.helix.model.Message;
+import org.apache.helix.participant.statemachine.StateModelFactory;
+
+
+/**
+ * Manages the custom Helix state transition thread pools for Pinot server.
+ * <br/>
+ * The implementation of this interface can be passed to {@link SegmentOnlineOfflineStateModelFactory} to provide custom
+ * thread pools for different state transition messages, instead of using Helix's managed thread pools.
+ * <br/>
+ * Helix maintains a cache from message identifier to assigned thread pool. Message identifiers are:
+ * <ol>
+ *   <li> {@link org.apache.helix.model.Message.MessageInfo} </li>
+ *   <li> (resourceName, fromState, toState) combination </li>
+ *   <li> resourceName </li>
+ * </ol>
+ * For each state transition message, Helix gets the message identifiers by the above order, and looks up the cache
+ * to find if it's mapped to a thread pool, executes the state transition on it if it's non-null in the cache. If
+ * three of the identifiers all map to null, the default Helix-managed thread pool would be used. During the lookup,
+ * it calls {@link SegmentOnlineOfflineStateModelFactory#getExecutorService} upon cache misses. The cache is never
+ * cleaned up until the server shuts down, so the method would only be called once for each argument combination
+ * (even if it returns null).
+ */
+public interface StateTransitionThreadPoolManager {
+  @Nullable
+  StateModelFactory.CustomizedExecutorService getExecutorService(Message.MessageInfo messageInfo);
+
+  @Nullable
+  ExecutorService getExecutorService(String resourceName, String fromState, String toState);
+
+  @Nullable
+  ExecutorService getExecutorService(String resourceName);
+
+  void shutdown();
+}

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -236,6 +236,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
@@ -21,17 +21,13 @@ package org.apache.pinot.spi.accounting;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * The {@code ThreadResourceUsageProvider} class providing the functionality of measuring the CPU time
- * and allocateBytes (JVM heap) for the current thread.
- */
+/// This class provides the functionality of measuring the CPU time and allocateBytes (JVM heap) for current thread.
 public class ThreadResourceUsageProvider {
   private ThreadResourceUsageProvider() {
   }
@@ -40,21 +36,135 @@ public class ThreadResourceUsageProvider {
 
   // used for getting the memory allocation function in hotspot jvm through reflection
   private static final String SUN_THREAD_MXBEAN_CLASS_NAME = "com.sun.management.ThreadMXBean";
-  private static final String SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME
-      = "isThreadAllocatedMemorySupported";
-  private static final String SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_ENABLED_NAME
-      = "isThreadAllocatedMemoryEnabled";
-  private static final String SUN_THREAD_MXBEAN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME
-      = "setThreadAllocatedMemoryEnabled";
-  private static final String SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_NAME = "getThreadAllocatedBytes";
-  private static final Method SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD;
+  private static final String SUN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME = "isThreadAllocatedMemorySupported";
+  private static final String SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME = "setThreadAllocatedMemoryEnabled";
+  private static final String SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME = "getCurrentThreadAllocatedBytes";
+  private static final String SUN_GET_THREAD_ALLOCATED_BYTES_NAME = "getThreadAllocatedBytes";
 
   private static final ThreadMXBean MX_BEAN = ManagementFactory.getThreadMXBean();
   private static final boolean IS_CURRENT_THREAD_CPU_TIME_SUPPORTED = MX_BEAN.isCurrentThreadCpuTimeSupported();
   private static final boolean IS_THREAD_ALLOCATED_MEMORY_SUPPORTED;
-  private static final boolean IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT;
-  private static boolean _isThreadCpuTimeMeasurementEnabled = false;
-  private static boolean _isThreadMemoryMeasurementEnabled = false;
+  private static final Method SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_METHOD;
+  private static final Method SUN_GET_THREAD_ALLOCATED_BYTES_METHOD;
+  private static final Method SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD;
+
+  private static boolean _isThreadCpuTimeMeasurementEnabled;
+  private static boolean _isThreadMemoryMeasurementEnabled;
+
+  // Initialize the com.sun.management.ThreadMXBean related variables using reflection
+  static {
+    Class<?> sunThreadMXBeanClass = null;
+    try {
+      sunThreadMXBeanClass = Class.forName(SUN_THREAD_MXBEAN_CLASS_NAME);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while loading: {}, you are probably not using Hotspot jvm",
+          SUN_THREAD_MXBEAN_CLASS_NAME, e);
+    }
+
+    boolean isThreadAllocatedMemorySupported = false;
+    Method setThreadAllocatedMemoryEnabled = null;
+    Method getCurrentThreadAllocatedBytes = null;
+    Method getThreadAllocatedBytes = null;
+    if (sunThreadMXBeanClass != null) {
+      try {
+        isThreadAllocatedMemorySupported =
+            (boolean) sunThreadMXBeanClass.getMethod(SUN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME).invoke(MX_BEAN);
+      } catch (Exception e) {
+        LOGGER.error("Caught exception invoking method: {}", SUN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME, e);
+      }
+      if (isThreadAllocatedMemorySupported) {
+        try {
+          setThreadAllocatedMemoryEnabled =
+              sunThreadMXBeanClass.getMethod(SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME, boolean.class);
+        } catch (Exception e) {
+          LOGGER.error("Caught exception loading method: {}", SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME, e);
+          isThreadAllocatedMemorySupported = false;
+        }
+      }
+      if (isThreadAllocatedMemorySupported) {
+        try {
+          getCurrentThreadAllocatedBytes = sunThreadMXBeanClass.getMethod(SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME);
+        } catch (Exception e1) {
+          LOGGER.info("Failed to load method: {}, loading: {} instead", SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME,
+              SUN_GET_THREAD_ALLOCATED_BYTES_NAME);
+          try {
+            getThreadAllocatedBytes = sunThreadMXBeanClass.getMethod(SUN_GET_THREAD_ALLOCATED_BYTES_NAME, long.class);
+          } catch (Exception e2) {
+            LOGGER.error("Caught exception loading method: {}", SUN_GET_THREAD_ALLOCATED_BYTES_NAME, e2);
+            isThreadAllocatedMemorySupported = false;
+          }
+        }
+      }
+    }
+
+    LOGGER.info("Current thread CPU time supported: {}", IS_CURRENT_THREAD_CPU_TIME_SUPPORTED);
+    LOGGER.info("Thread allocated memory supported: {}", isThreadAllocatedMemorySupported);
+    if (isThreadAllocatedMemorySupported) {
+      LOGGER.info("Using: {} to read current thread allocated bytes",
+          getCurrentThreadAllocatedBytes != null ? SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME
+              : SUN_GET_THREAD_ALLOCATED_BYTES_NAME);
+    }
+    IS_THREAD_ALLOCATED_MEMORY_SUPPORTED = isThreadAllocatedMemorySupported;
+    SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_METHOD = setThreadAllocatedMemoryEnabled;
+    SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD = getCurrentThreadAllocatedBytes;
+    SUN_GET_THREAD_ALLOCATED_BYTES_METHOD = getThreadAllocatedBytes;
+  }
+
+  public static boolean isThreadCpuTimeMeasurementEnabled() {
+    return _isThreadCpuTimeMeasurementEnabled;
+  }
+
+  public static void setThreadCpuTimeMeasurementEnabled(boolean enable) {
+    if (!IS_CURRENT_THREAD_CPU_TIME_SUPPORTED) {
+      assert !_isThreadCpuTimeMeasurementEnabled;
+      if (enable) {
+        LOGGER.error("Not enabling thread CPU time measurement because it is not supported");
+      }
+      return;
+    }
+    if (_isThreadCpuTimeMeasurementEnabled != enable) {
+      if (enable) {
+        LOGGER.info("Enabling thread CPU time measurement");
+      } else {
+        LOGGER.info("Disabling thread CPU time measurement");
+      }
+    }
+    try {
+      MX_BEAN.setThreadCpuTimeEnabled(enable);
+      _isThreadCpuTimeMeasurementEnabled = enable;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception {} thread CPU time measurement", enable ? "enabling" : "disabling", e);
+      _isThreadCpuTimeMeasurementEnabled = false;
+    }
+  }
+
+  public static boolean isThreadMemoryMeasurementEnabled() {
+    return _isThreadMemoryMeasurementEnabled;
+  }
+
+  public static void setThreadMemoryMeasurementEnabled(boolean enable) {
+    if (!IS_THREAD_ALLOCATED_MEMORY_SUPPORTED) {
+      assert !_isThreadMemoryMeasurementEnabled;
+      if (enable) {
+        LOGGER.error("Not enabling thread memory measurement because it is not supported");
+      }
+      return;
+    }
+    if (_isThreadMemoryMeasurementEnabled != enable) {
+      if (enable) {
+        LOGGER.info("Enabling thread memory measurement");
+      } else {
+        LOGGER.info("Disabling thread memory measurement");
+      }
+    }
+    try {
+      SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_METHOD.invoke(MX_BEAN, enable);
+      _isThreadMemoryMeasurementEnabled = enable;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception {} thread memory measurement", enable ? "enabling" : "disabling", e);
+      _isThreadMemoryMeasurementEnabled = false;
+    }
+  }
 
   public static int getThreadCount() {
     return MX_BEAN.getThreadCount();
@@ -69,12 +179,24 @@ public class ThreadResourceUsageProvider {
   }
 
   public static long getCurrentThreadAllocatedBytes() {
-    try {
-      return _isThreadMemoryMeasurementEnabled ? (long) SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD
-          .invoke(MX_BEAN, Thread.currentThread().getId()) : 0;
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      LOGGER.error("Exception happened during the invocation of getting current bytes allocated", e);
+    if (!_isThreadMemoryMeasurementEnabled) {
       return 0;
+    }
+    if (SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD != null) {
+      try {
+        return (long) SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD.invoke(MX_BEAN);
+      } catch (Exception e) {
+        LOGGER.error("Caught exception invoking method: {}", SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME, e);
+        return 0;
+      }
+    } else {
+      assert SUN_GET_THREAD_ALLOCATED_BYTES_METHOD != null;
+      try {
+        return (long) SUN_GET_THREAD_ALLOCATED_BYTES_METHOD.invoke(MX_BEAN, Thread.currentThread().getId());
+      } catch (Exception e) {
+        LOGGER.error("Caught exception invoking method: {}", SUN_GET_THREAD_ALLOCATED_BYTES_NAME, e);
+        return 0;
+      }
     }
   }
 
@@ -89,86 +211,5 @@ public class ThreadResourceUsageProvider {
       }
     }
     return totalGCTime;
-  }
-
-  public static boolean isThreadCpuTimeMeasurementEnabled() {
-    return _isThreadCpuTimeMeasurementEnabled;
-  }
-
-  public static void setThreadCpuTimeMeasurementEnabled(boolean enable) {
-    _isThreadCpuTimeMeasurementEnabled = enable && IS_CURRENT_THREAD_CPU_TIME_SUPPORTED;
-  }
-
-  public static boolean isThreadMemoryMeasurementEnabled() {
-    return _isThreadMemoryMeasurementEnabled;
-  }
-
-  public static void setThreadMemoryMeasurementEnabled(boolean enable) {
-
-    boolean isThreadAllocateMemoryEnabled = IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT;
-    // if the jvm default enabling config is different
-    if (enable != IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT) {
-      try {
-        Class<?> sunThreadMXBeanClass = Class.forName(SUN_THREAD_MXBEAN_CLASS_NAME);
-        sunThreadMXBeanClass.getMethod(SUN_THREAD_MXBEAN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME, Boolean.TYPE)
-            .invoke(MX_BEAN, enable);
-        isThreadAllocateMemoryEnabled = (boolean) sunThreadMXBeanClass
-            .getMethod(SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_ENABLED_NAME)
-            .invoke(MX_BEAN);
-      } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-        LOGGER.error("Not able to call isThreadAllocatedMemoryEnabled or setThreadAllocatedMemoryEnabled, ", e);
-      }
-    }
-    _isThreadMemoryMeasurementEnabled = enable && IS_THREAD_ALLOCATED_MEMORY_SUPPORTED && isThreadAllocateMemoryEnabled;
-  }
-
-  //initialize the com.sun.management.ThreadMXBean related variables using reflection
-  static {
-    Class<?> sunThreadMXBeanClass;
-    try {
-      sunThreadMXBeanClass = Class.forName(SUN_THREAD_MXBEAN_CLASS_NAME);
-    } catch (ClassNotFoundException e) {
-      LOGGER.error("Not able to load com.sun.management.ThreadMXBean, you are probably not using Hotspot jvm");
-      sunThreadMXBeanClass = null;
-    }
-
-    boolean isThreadAllocateMemorySupported = false;
-    try {
-      isThreadAllocateMemorySupported =
-          sunThreadMXBeanClass != null && (boolean) sunThreadMXBeanClass
-              .getMethod(SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME)
-              .invoke(MX_BEAN);
-    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-      LOGGER.error("Not able to call isThreadAllocatedMemorySupported, ", e);
-    }
-    IS_THREAD_ALLOCATED_MEMORY_SUPPORTED = isThreadAllocateMemorySupported;
-
-    boolean isThreadAllocateMemoryEnabled = false;
-    try {
-      isThreadAllocateMemoryEnabled =
-          sunThreadMXBeanClass != null && (boolean) sunThreadMXBeanClass
-              .getMethod(SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_ENABLED_NAME)
-              .invoke(MX_BEAN);
-    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-      LOGGER.error("Not able to call isThreadAllocatedMemoryEnabled, ", e);
-    }
-    IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT = isThreadAllocateMemoryEnabled;
-
-    Method threadAllocateBytes = null;
-    if (IS_THREAD_ALLOCATED_MEMORY_SUPPORTED) {
-      try {
-        threadAllocateBytes = sunThreadMXBeanClass
-            .getMethod(SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_NAME, long.class);
-      } catch (NoSuchMethodException ignored) {
-      }
-    }
-    SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD = threadAllocateBytes;
-  }
-
-  static {
-    LOGGER.info("Current thread cpu time measurement supported: {}", IS_CURRENT_THREAD_CPU_TIME_SUPPORTED);
-    LOGGER.info("Current thread allocated bytes measurement supported: {}", IS_THREAD_ALLOCATED_MEMORY_SUPPORTED);
-    LOGGER.info("Current thread allocated bytes measurement enabled default: {}",
-        IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/AccessType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/AccessType.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.spi.config.user;
 
 public enum AccessType {
-    CREATE, READ, UPDATE, DELETE
+  CREATE, READ, UPDATE, DELETE
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/ComponentType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/ComponentType.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.spi.config.user;
 
 public enum ComponentType {
-    CONTROLLER, BROKER, SERVER, MINION, PROXY
+  CONTROLLER, BROKER, SERVER, MINION, PROXY
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/RoleType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/RoleType.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.spi.config.user;
 
 public enum RoleType {
-    ADMIN, USER
+  ADMIN, USER
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.user;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
@@ -85,6 +86,7 @@ public class UserConfig extends BaseJsonConfig {
     return _username;
   }
 
+  @JsonIgnore
   public String getUsernameWithComponent() {
     return getUserName() + "_" + getComponentType().toString();
   }
@@ -109,8 +111,17 @@ public class UserConfig extends BaseJsonConfig {
   }
 
   @JsonProperty(PERMISSIONS_KEY)
-  public List<AccessType> getPermissios() {
+  public List<AccessType> getPermissions() {
     return _permissions;
+  }
+
+  /**
+   * @deprecated Use {@link #getPermissions()} instead. This method has a typo in its name.
+   */
+  @JsonIgnore
+  @Deprecated
+  public List<AccessType> getPermissios() {
+    return getPermissions();
   }
 
   @JsonProperty(COMPONET_KEY)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
@@ -29,123 +29,122 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class UserConfig extends BaseJsonConfig {
-    public static final String USERNAME_KEY = "username";
-    public static final String PASSWORD_KEY = "password";
-    public static final String COMPONET_KEY = "component";
-    public static final String ROLE_KEY = "role";
-    public static final String AUTH_TOKEN_KEY = "authToken";
-    public static final String TABLES_KEY = "tables";
-    public static final String EXCLUDE_TABLES_KEY = "excludeTables";
-    public static final String PERMISSIONS_KEY = "permissions";
+  public static final String USERNAME_KEY = "username";
+  public static final String PASSWORD_KEY = "password";
+  public static final String COMPONET_KEY = "component";
+  public static final String ROLE_KEY = "role";
+  public static final String AUTH_TOKEN_KEY = "authToken";
+  public static final String TABLES_KEY = "tables";
+  public static final String EXCLUDE_TABLES_KEY = "excludeTables";
+  public static final String PERMISSIONS_KEY = "permissions";
 
-    @JsonPropertyDescription("The name of User")
-    private String _username;
+  @JsonPropertyDescription("The name of User")
+  private String _username;
 
-    @JsonPropertyDescription("The password of User")
-    private String _password;
+  @JsonPropertyDescription("The password of User")
+  private String _password;
 
-    @JsonPropertyDescription("The name of Component")
-    private ComponentType _componentType;
+  @JsonPropertyDescription("The name of Component")
+  private ComponentType _componentType;
 
-    @JsonPropertyDescription("The role of user")
-    private RoleType _roleType;
+  @JsonPropertyDescription("The role of user")
+  private RoleType _roleType;
 
-    @JsonPropertyDescription("The tables owned of User")
-    private List<String> _tables;
+  @JsonPropertyDescription("The tables owned of User")
+  private List<String> _tables;
 
-    @JsonPropertyDescription("The tables excluded for User")
-    private List<String> _excludeTables;
+  @JsonPropertyDescription("The tables excluded for User")
+  private List<String> _excludeTables;
 
-    @JsonPropertyDescription("The table permission of User")
-    private List<AccessType> _permissions;
+  @JsonPropertyDescription("The table permission of User")
+  private List<AccessType> _permissions;
 
-    @JsonCreator
-    public UserConfig(@JsonProperty(value = USERNAME_KEY, required = true) String username,
-        @JsonProperty(value = PASSWORD_KEY, required = true) String password,
-        @JsonProperty(value = COMPONET_KEY, required = true) String component,
-        @JsonProperty(value = ROLE_KEY, required = true) String role,
-        @JsonProperty(value = TABLES_KEY) @Nullable List<String> tableList,
-        @JsonProperty(value = EXCLUDE_TABLES_KEY) @Nullable List<String> excludeTableList,
-        @JsonProperty(value = PERMISSIONS_KEY) @Nullable List<AccessType> permissionList
-    ) {
-        Preconditions.checkArgument(username != null, "'username' must be configured");
-        Preconditions.checkArgument(password != null, "'password' must be configured");
+  @JsonCreator
+  public UserConfig(@JsonProperty(value = USERNAME_KEY, required = true) String username,
+      @JsonProperty(value = PASSWORD_KEY, required = true) String password,
+      @JsonProperty(value = COMPONET_KEY, required = true) String component,
+      @JsonProperty(value = ROLE_KEY, required = true) String role,
+      @JsonProperty(value = TABLES_KEY) @Nullable List<String> tableList,
+      @JsonProperty(value = EXCLUDE_TABLES_KEY) @Nullable List<String> excludeTableList,
+      @JsonProperty(value = PERMISSIONS_KEY) @Nullable List<AccessType> permissionList) {
+    Preconditions.checkArgument(username != null, "'username' must be configured");
+    Preconditions.checkArgument(password != null, "'password' must be configured");
 
-        // NOTE: Handle lower case table type and raw table name for backward-compatibility
-        _username = username;
-        _password = password;
-        _componentType = ComponentType.valueOf(component.toUpperCase());
-        _roleType = RoleType.valueOf(role.toUpperCase());
-        _tables = tableList;
-        _excludeTables = excludeTableList;
-        _permissions = permissionList;
+    // NOTE: Handle lower case table type and raw table name for backward-compatibility
+    _username = username;
+    _password = password;
+    _componentType = ComponentType.valueOf(component.toUpperCase());
+    _roleType = RoleType.valueOf(role.toUpperCase());
+    _tables = tableList;
+    _excludeTables = excludeTableList;
+    _permissions = permissionList;
+  }
+
+  @JsonProperty(USERNAME_KEY)
+  public String getUserName() {
+    return _username;
+  }
+
+  public String getUsernameWithComponent() {
+    return getUserName() + "_" + getComponentType().toString();
+  }
+
+  public boolean isExist(String username, ComponentType component) {
+    return _username.equals(username) && _componentType.equals(component);
+  }
+
+  @JsonProperty(PASSWORD_KEY)
+  public String getPassword() {
+    return _password;
+  }
+
+  @JsonProperty(TABLES_KEY)
+  public List<String> getTables() {
+    return _tables;
+  }
+
+  @JsonProperty(EXCLUDE_TABLES_KEY)
+  public List<String> getExcludeTables() {
+    return _excludeTables;
+  }
+
+  @JsonProperty(PERMISSIONS_KEY)
+  public List<AccessType> getPermissios() {
+    return _permissions;
+  }
+
+  @JsonProperty(COMPONET_KEY)
+  public ComponentType getComponentType() {
+    return _componentType;
+  }
+
+  @JsonProperty(ROLE_KEY)
+  public RoleType getRoleType() {
+    return _roleType;
+  }
+
+  public void setRole(String roleTypeStr) {
+    _roleType = RoleType.valueOf(roleTypeStr);
+  }
+
+  public void setPassword(String password) {
+    _password = password;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
-
-    @JsonProperty(USERNAME_KEY)
-    public String getUserName() {
-        return _username;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
+    UserConfig that = (UserConfig) o;
+    return _username.equals(that._username) && _componentType == that._componentType;
+  }
 
-    public String getUsernameWithComponent() {
-        return getUserName() + "_" + getComponentType().toString();
-    }
-
-    public boolean isExist(String username, ComponentType component) {
-        return _username.equals(username) && _componentType.equals(component);
-    }
-
-    @JsonProperty(PASSWORD_KEY)
-    public String getPassword() {
-        return _password;
-    }
-
-    @JsonProperty(TABLES_KEY)
-    public List<String> getTables() {
-        return _tables;
-    }
-
-    @JsonProperty(EXCLUDE_TABLES_KEY)
-    public List<String> getExcludeTables() {
-        return _excludeTables;
-    }
-
-    @JsonProperty(PERMISSIONS_KEY)
-    public List<AccessType> getPermissios() {
-        return _permissions;
-    }
-
-    @JsonProperty(COMPONET_KEY)
-    public ComponentType getComponentType() {
-        return _componentType;
-    }
-
-    @JsonProperty(ROLE_KEY)
-    public RoleType getRoleType() {
-        return _roleType;
-    }
-
-    public void setRole(String roleTypeStr) {
-        _roleType = RoleType.valueOf(roleTypeStr);
-    }
-
-    public void setPassword(String password) {
-        _password = password;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        UserConfig that = (UserConfig) o;
-        return _username.equals(that._username) && _componentType == that._componentType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), _username, _componentType);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), _username, _componentType);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/ColumnarDataSource.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/ColumnarDataSource.java
@@ -20,6 +20,9 @@ package org.apache.pinot.spi.data.readers;
 
 import java.io.Closeable;
 import java.io.IOException;
+import javax.annotation.Nullable;
+import org.roaringbitmap.RoaringBitmap;
+
 
 /**
  * <p>
@@ -63,4 +66,19 @@ public interface ColumnarDataSource extends Closeable {
    * @return a description of the underlying source (e.g., file name)
    */
   String toString();
+
+
+  /**
+   * Returns the valid document IDs bitmap for this data source.
+   * Documents not in this bitmap will be filtered out during processing.
+   * <p>
+   * This is used for scenarios like upsert compaction where only valid (non-obsolete)
+   * documents should be processed.
+   *
+   * @return RoaringBitmap of valid doc IDs, or null if all docs are valid
+   */
+  @Nullable
+  default RoaringBitmap getValidDocIds() {
+    return null;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.exception;
 
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
 import javax.annotation.Nonnegative;
 import javax.ws.rs.core.Response;
@@ -67,6 +68,23 @@ public enum QueryErrorCode {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryErrorCode.class);
 
   private static final QueryErrorCode[] BY_ID;
+
+  // Static set of SLA-critical (system) error codes
+  private static final EnumSet<QueryErrorCode> CRITICAL_ERROR_CODES = EnumSet.of(
+      SQL_RUNTIME,
+      INTERNAL,
+      QUERY_SCHEDULING_TIMEOUT,
+      EXECUTION_TIMEOUT,
+      BROKER_TIMEOUT,
+      SERVER_SEGMENT_MISSING,
+      BROKER_SEGMENT_UNAVAILABLE,
+      SERVER_NOT_RESPONDING,
+      BROKER_REQUEST_SEND,
+      MERGE_RESPONSE,
+      QUERY_CANCELLATION,
+      SERVER_SHUTTING_DOWN,
+      QUERY_PLANNING
+  );
 
   static {
     int maxId = -1;
@@ -172,5 +190,13 @@ public enum QueryErrorCode {
       default:
         return false;
     }
+  }
+
+  /**
+   * Returns true if the error is considered critical for SLA accounting.
+   * Critical errors represent system-side failures (timeouts, internal errors, infra issues, etc.).
+   */
+  public boolean isCriticalError() {
+    return CRITICAL_ERROR_CODES.contains(this);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -59,6 +59,7 @@ public enum QueryErrorCode {
   INTERNAL(450, "InternalError", Response.Status.INTERNAL_SERVER_ERROR),
   MERGE_RESPONSE(500, "MergeResponseError", Response.Status.INTERNAL_SERVER_ERROR),
   QUERY_CANCELLATION(503, "QueryCancellationError", Response.Status.SERVICE_UNAVAILABLE),
+  REMOTE_CLUSTER_UNAVAILABLE(510, "RemoteClusterUnavailable", Response.Status.SERVICE_UNAVAILABLE),
   /// Error detected at validation time. For example, type mismatch.
   QUERY_VALIDATION(700, "QueryValidationError", Response.Status.BAD_REQUEST),
   UNKNOWN_COLUMN(710, "UnknownColumnError", Response.Status.BAD_REQUEST),

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
@@ -34,9 +34,14 @@ public abstract class BasePinotFS implements PinotFS {
   @Override
   public boolean deleteBatch(List<URI> segmentUris, boolean forceDelete)
       throws IOException {
+    if (segmentUris == null || segmentUris.isEmpty()) {
+      return true;
+    }
     boolean result = true;
     for (URI segmentUri : segmentUris) {
-      result &= delete(segmentUri, forceDelete);
+      if (!delete(segmentUri, forceDelete)) {
+        result = false;
+      }
     }
     return result;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1811,6 +1811,7 @@ public class CommonConstants {
     public static final String TOTAL_DOCS = "segment.total.docs";
     public static final String CRC = "segment.crc";
     public static final String DATA_CRC = "segment.data.crc";
+    public static final String USE_DATA_CRC = "segment.use.data.crc";
     public static final String TIER = "segment.tier";
     public static final String CREATION_TIME = "segment.creation.time";
     public static final String PUSH_TIME = "segment.push.time";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -159,6 +159,9 @@ public class CommonConstants {
     public static final String UNTAGGED_BROKER_INSTANCE = "broker_untagged";
     public static final String UNTAGGED_SERVER_INSTANCE = "server_untagged";
     public static final String UNTAGGED_MINION_INSTANCE = "minion_untagged";
+    public static final String DRAINED_MINION_INSTANCE = "minion_drained";
+
+    public static final String PREVIOUS_TAGS = "previousTags";
 
     public static class StateModel {
       public static class SegmentStateModel {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2155,4 +2155,21 @@ public class CommonConstants {
     public static final String TABLE_CONFIG_PATH_PREFIX = "/CONFIGS/TABLE/";
     public static final String SCHEMA_PATH_PREFIX = "/SCHEMAS/";
   }
+
+  /**
+   * Constants for cluster config change listeners.
+   */
+  public static class ConfigChangeListenerConstants {
+    /**
+     * Cluster config key to control whether force commit/reload is allowed for upsert tables
+     * with inconsistent state configurations (partial upsert or dropOutOfOrderRecord=true
+     * with consistency mode NONE and replication > 1).
+     */
+    public static final String FORCE_COMMIT_RELOAD_CONFIG = "pinot.server.upsert.force.commit.reload";
+
+    /**
+     * Default value: true (force commit/reload is allowed by default).
+     */
+    public static final boolean DEFAULT_FORCE_COMMIT_RELOAD = true;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1635,6 +1635,8 @@ public class CommonConstants {
     public static final String CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST = "segmentsForceCommitted";
     public static final String CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED_LIST = "segmentsYetToBeCommitted";
     public static final String NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED = "numberOfSegmentsYetToBeCommitted";
+    // Table Replication job props
+    public static final String SEGMENTS_TO_BE_COPIED = "segmentsToBeCopied";
   }
 
   // prefix for scheduler related features, e.g. query accountant

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1637,6 +1637,9 @@ public class CommonConstants {
     public static final String NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED = "numberOfSegmentsYetToBeCommitted";
     // Table Replication job props
     public static final String SEGMENTS_TO_BE_COPIED = "segmentsToBeCopied";
+    public static final String CONSUMER_WATERMARKS = "consumerWatermarks";
+    public static final String REPLICATION_PROGRESS = "replicationProgress";
+    public static final String REPLICATION_JOB_STATUS = "replicationJobStatus";
   }
 
   // prefix for scheduler related features, e.g. query accountant

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -247,6 +247,20 @@ public class JsonUtils {
     return DEFAULT_READER.forType(MAP_TYPE_REFERENCE).readValue(jsonNode);
   }
 
+  /**
+   * Parses JSON bytes directly to a Map, avoiding the intermediate JsonNode representation.
+   * This is more efficient than calling bytesToJsonNode followed by jsonNodeToMap.
+   */
+  public static Map<String, Object> bytesToMap(byte[] jsonBytes)
+      throws IOException {
+    return DEFAULT_READER.forType(MAP_TYPE_REFERENCE).readValue(jsonBytes);
+  }
+
+  public static Map<String, Object> bytesToMap(byte[] jsonBytes, int offset, int length)
+      throws IOException {
+    return DEFAULT_READER.forType(MAP_TYPE_REFERENCE).readValue(jsonBytes, offset, length);
+  }
+
   public static String objectToString(Object object)
       throws JsonProcessingException {
     return DEFAULT_WRITER.writeValueAsString(object);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.utils.builder;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -123,6 +124,21 @@ public class ControllerRequestURLBuilder {
 
   public String forDeleteMinionTask(String taskName) {
     return StringUtil.join("/", _baseUrl, "tasks", "task", taskName);
+  }
+
+  public String forMinionStatus(@Nullable String statusFilter, boolean includeTaskCounts) {
+    StringBuilder url = new StringBuilder(StringUtil.join("/", _baseUrl, "minions", "status"));
+    List<String> params = new ArrayList<>();
+    if (statusFilter != null && !statusFilter.isEmpty()) {
+      params.add("status=" + statusFilter);
+    }
+    if (includeTaskCounts) {
+      params.add("includeTaskCounts=true");
+    }
+    if (!params.isEmpty()) {
+      url.append("?").append(String.join("&", params));
+    }
+    return url.toString();
   }
 
   public String forStopMinionTaskQueue(String taskType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -347,6 +347,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "schema");
   }
 
+  public String forConsumerWatermarksGet(String tableName) {
+    return StringUtil.join("/", _baseUrl, "tables", tableName, "consumerWatermarks");
+  }
+
   public String forTableExternalView(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "externalview");
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java
@@ -24,53 +24,53 @@ import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.RoleType;
 import org.apache.pinot.spi.config.user.UserConfig;
 
+
 public class UserConfigBuilder {
+  private ComponentType _componentType;
+  private String _username;
+  private String _password;
+  private RoleType _roleType;
+  private List<String> _tableList;
+  private List<String> _excludeTableList;
+  private List<AccessType> _permissionList;
 
-    private ComponentType _componentType;
-    private String _username;
-    private String _password;
-    private RoleType _roleType;
-    private List<String> _tableList;
-    private List<String> _excludeTableList;
-    private List<AccessType> _permissionList;
+  public UserConfigBuilder setComponentType(ComponentType componentType) {
+    _componentType = componentType;
+    return this;
+  }
 
-    public UserConfigBuilder setComponentType(ComponentType componentType) {
-        _componentType = componentType;
-        return this;
-    }
+  public UserConfigBuilder setUsername(String username) {
+    _username = username;
+    return this;
+  }
 
-    public UserConfigBuilder setUsername(String username) {
-        _username = username;
-        return this;
-    }
+  public UserConfigBuilder setPassword(String password) {
+    _password = password;
+    return this;
+  }
 
-    public UserConfigBuilder setPassword(String password) {
-        _password = password;
-        return this;
-    }
+  public UserConfigBuilder setRoleType(RoleType roleType) {
+    _roleType = roleType;
+    return this;
+  }
 
-    public UserConfigBuilder setRoleType(RoleType roleType) {
-        _roleType = roleType;
-        return this;
-    }
+  public UserConfigBuilder setTableList(List<String> tableList) {
+    _tableList = tableList;
+    return this;
+  }
 
-    public UserConfigBuilder setTableList(List<String> tableList) {
-        _tableList = tableList;
-        return this;
-    }
+  public UserConfigBuilder setExcludeTableList(List<String> excludeTableList) {
+    _excludeTableList = excludeTableList;
+    return this;
+  }
 
-    public UserConfigBuilder setExcludeTableList(List<String> excludeTableList) {
-        _excludeTableList = excludeTableList;
-        return this;
-    }
+  public UserConfigBuilder setPermissionList(List<AccessType> permissionList) {
+    _permissionList = permissionList;
+    return this;
+  }
 
-    public UserConfigBuilder setPermissionList(List<AccessType> permissionList) {
-        _permissionList = permissionList;
-        return this;
-    }
-
-    public UserConfig build() {
-        return new UserConfig(_username, _password, _componentType.toString(), _roleType.toString(), _tableList,
-            _excludeTableList, _permissionList);
-    }
+  public UserConfig build() {
+    return new UserConfig(_username, _password, _componentType.toString(), _roleType.toString(), _tableList,
+        _excludeTableList, _permissionList);
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/user/UserConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/user/UserConfigTest.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.user;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class UserConfigTest {
+
+  @Test
+  public void testJsonSerializationExcludesDeprecatedMethods()
+      throws IOException {
+    // Create a UserConfig instance
+    List<String> tables = Arrays.asList("table1", "table2");
+    List<String> excludeTables = Arrays.asList("excludeTable1");
+    List<AccessType> permissions = Arrays.asList(AccessType.READ, AccessType.UPDATE);
+
+    UserConfig userConfig = new UserConfig(
+        "testUser",
+        "testPassword",
+        "BROKER",
+        "ADMIN",
+        tables,
+        excludeTables,
+        permissions
+    );
+
+    // Serialize to JSON
+    String jsonString = userConfig.toJsonString();
+    JsonNode jsonNode = JsonUtils.stringToJsonNode(jsonString);
+
+    // Verify standard fields are present
+    assertTrue(jsonNode.has("username"));
+    assertEquals(jsonNode.get("username").asText(), "testUser");
+    assertTrue(jsonNode.has("password"));
+    assertEquals(jsonNode.get("password").asText(), "testPassword");
+    assertTrue(jsonNode.has("component"));
+    assertEquals(jsonNode.get("component").asText(), "BROKER");
+    assertTrue(jsonNode.has("role"));
+    assertEquals(jsonNode.get("role").asText(), "ADMIN");
+    assertTrue(jsonNode.has("tables"));
+    assertTrue(jsonNode.has("excludeTables"));
+    assertTrue(jsonNode.has("permissions"));
+    assertEquals(jsonNode.get("permissions").size(), 2);
+
+    // Verify deprecated method with typo is NOT in JSON (should be excluded by @JsonIgnore)
+    assertFalse(jsonNode.has("permissios"),
+        "Deprecated method 'getPermissios()' should not be serialized to JSON");
+
+    // Verify correct permissions field is present (not the typo'd one)
+    assertTrue(jsonNode.has("permissions"),
+        "Correct 'getPermissions()' method should be serialized to JSON");
+
+    // Verify utility method is NOT in JSON (should be excluded by @JsonIgnore)
+    assertFalse(jsonNode.has("usernameWithComponent"),
+        "Utility method 'getUsernameWithComponent()' should not be serialized to JSON");
+  }
+
+  @Test
+  public void testJsonDeserializationWithAllFields()
+      throws IOException {
+    String jsonString = "{"
+        + "\"username\":\"admin\","
+        + "\"password\":\"secret\","
+        + "\"component\":\"CONTROLLER\","
+        + "\"role\":\"ADMIN\","
+        + "\"tables\":[\"users\",\"orders\"],"
+        + "\"excludeTables\":[\"temp\"],"
+        + "\"permissions\":[\"CREATE\",\"READ\",\"UPDATE\",\"DELETE\"]"
+        + "}";
+
+    UserConfig userConfig = JsonUtils.stringToObject(jsonString, UserConfig.class);
+
+    assertNotNull(userConfig);
+    assertEquals(userConfig.getUserName(), "admin");
+    assertEquals(userConfig.getPassword(), "secret");
+    assertEquals(userConfig.getComponentType(), ComponentType.CONTROLLER);
+    assertEquals(userConfig.getRoleType(), RoleType.ADMIN);
+    assertEquals(userConfig.getTables().size(), 2);
+    assertTrue(userConfig.getTables().contains("users"));
+    assertTrue(userConfig.getTables().contains("orders"));
+    assertEquals(userConfig.getExcludeTables().size(), 1);
+    assertTrue(userConfig.getExcludeTables().contains("temp"));
+    assertEquals(userConfig.getPermissions().size(), 4);
+
+    // Verify deprecated method still works for backward compatibility in Java API
+    assertEquals(userConfig.getPermissios(), userConfig.getPermissions(),
+        "Deprecated method should return same value as correct method");
+  }
+
+  @Test
+  public void testJsonDeserializationWithMinimalFields()
+      throws IOException {
+    String jsonString = "{"
+        + "\"username\":\"user1\","
+        + "\"password\":\"pass123\","
+        + "\"component\":\"BROKER\","
+        + "\"role\":\"USER\""
+        + "}";
+
+    UserConfig userConfig = JsonUtils.stringToObject(jsonString, UserConfig.class);
+
+    assertNotNull(userConfig);
+    assertEquals(userConfig.getUserName(), "user1");
+    assertEquals(userConfig.getPassword(), "pass123");
+    assertEquals(userConfig.getComponentType(), ComponentType.BROKER);
+    assertEquals(userConfig.getRoleType(), RoleType.USER);
+    assertNull(userConfig.getTables());
+    assertNull(userConfig.getExcludeTables());
+    assertNull(userConfig.getPermissions());
+    assertNull(userConfig.getPermissios()); // Deprecated method should also return null
+  }
+
+  @Test
+  public void testSerializationRoundTrip()
+      throws IOException {
+    // Create a UserConfig with all fields
+    List<AccessType> permissions = Arrays.asList(AccessType.READ, AccessType.UPDATE);
+    UserConfig original = new UserConfig(
+        "testuser",
+        "testpass",
+        "server",  // Test case-insensitive conversion
+        "user",    // Test case-insensitive conversion
+        Arrays.asList("table1"),
+        Arrays.asList("exclude1"),
+        permissions
+    );
+
+    // Serialize and deserialize
+    String jsonString = original.toJsonString();
+    UserConfig deserialized = JsonUtils.stringToObject(jsonString, UserConfig.class);
+
+    // Verify all fields match
+    assertEquals(deserialized.getUserName(), original.getUserName());
+    assertEquals(deserialized.getPassword(), original.getPassword());
+    assertEquals(deserialized.getComponentType(), original.getComponentType());
+    assertEquals(deserialized.getRoleType(), original.getRoleType());
+    assertEquals(deserialized.getTables(), original.getTables());
+    assertEquals(deserialized.getExcludeTables(), original.getExcludeTables());
+    assertEquals(deserialized.getPermissions(), original.getPermissions());
+
+    // Verify the serialized JSON doesn't contain deprecated/utility methods
+    JsonNode jsonNode = JsonUtils.stringToJsonNode(jsonString);
+    assertFalse(jsonNode.has("permissios"),
+        "Deprecated method 'getPermissios()' should not be serialized");
+    assertFalse(jsonNode.has("usernameWithComponent"),
+        "Utility method 'getUsernameWithComponent()' should not be serialized");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,9 +36,11 @@ import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -762,5 +766,497 @@ public class JsonUtilsTest {
       assertEquals(flattenedRecord1.get(".addresses..country"), "ca");
       assertEquals(flattenedRecord1.get(".addresses..street"), "second st");
     }
+  }
+
+  // ==================== Tests for bytesToMap optimization ====================
+  // These tests verify that bytesToMap produces identical results to the old
+  // two-step approach (bytesToJsonNode + jsonNodeToMap)
+
+  /**
+   * Data provider for various JSON payloads to test bytesToMap equivalence
+   */
+  @DataProvider(name = "jsonPayloads")
+  public Object[][] jsonPayloads() {
+    return new Object[][]{
+        // Empty and null cases
+        {"{}"},
+        {"{\"key\":null}"},
+
+        // Simple primitives
+        {"{\"string\":\"value\"}"},
+        {"{\"integer\":42}"},
+        {"{\"negative\":-123}"},
+        {"{\"float\":3.14159}"},
+        {"{\"negative_float\":-2.718}"},
+        {"{\"boolean_true\":true}"},
+        {"{\"boolean_false\":false}"},
+        {"{\"zero\":0}"},
+        {"{\"zero_float\":0.0}"},
+
+        // Large numbers
+        {"{\"large_int\":9223372036854775807}"},
+        {"{\"large_negative\":-9223372036854775808}"},
+        {"{\"scientific\":1.23e10}"},
+        {"{\"scientific_negative\":1.23e-10}"},
+
+        // String edge cases
+        {"{\"empty_string\":\"\"}"},
+        {"{\"whitespace\":\"   \"}"},
+        {"{\"with_quotes\":\"she said \\\"hello\\\"\"}"},
+        {"{\"with_backslash\":\"path\\\\to\\\\file\"}"},
+        {"{\"with_newline\":\"line1\\nline2\"}"},
+        {"{\"with_tab\":\"col1\\tcol2\"}"},
+        {"{\"with_unicode\":\"日本語\"}"},
+        {"{\"emoji\":\"Hello 👋 World 🌍\"}"},
+        {"{\"special_chars\":\"<>&'\\\"\"}"},
+
+        // Arrays
+        {"{\"empty_array\":[]}"},
+        {"{\"int_array\":[1,2,3,4,5]}"},
+        {"{\"string_array\":[\"a\",\"b\",\"c\"]}"},
+        {"{\"mixed_array\":[1,\"two\",3.0,true,null]}"},
+        {"{\"nested_array\":[[1,2],[3,4],[5,6]]}"},
+        {"{\"array_of_objects\":[{\"a\":1},{\"b\":2}]}"},
+
+        // Nested objects
+        {"{\"nested\":{\"level1\":{\"level2\":{\"level3\":\"deep\"}}}}"},
+        {"{\"person\":{\"name\":\"John\",\"age\":30,\"address\":{\"city\":\"NYC\",\"zip\":\"10001\"}}}"},
+
+        // Complex realistic payloads
+        {
+            "{\"event\":{\"id\":123,\"type\":\"click\",\"timestamp\":1609459200000,"
+                + "\"user\":{\"id\":\"user123\",\"session\":\"sess456\"},"
+                + "\"data\":{\"page\":\"/products\",\"element\":\"button\",\"coordinates\":{\"x\":100,\"y\":200}}}}"
+        },
+
+        // Multiple fields with same type
+        {"{\"a\":1,\"b\":2,\"c\":3,\"d\":4,\"e\":5,\"f\":6,\"g\":7,\"h\":8,\"i\":9,\"j\":10}"},
+
+        // Field names with special characters
+        {"{\"field-with-dash\":1}"},
+        {"{\"field.with.dots\":2}"},
+        {"{\"field_with_underscore\":3}"},
+        {"{\"123numeric_start\":4}"},
+
+        // Boolean and null combinations
+        {"{\"flags\":{\"active\":true,\"deleted\":false,\"pending\":null}}"},
+
+        // Array with nulls
+        {"{\"array_with_nulls\":[1,null,3,null,5]}"},
+
+        // Unicode field names
+        {"{\"日本語キー\":\"value\"}"},
+
+        // Very long string value
+        {"{\"long_string\":\"" + "a".repeat(1000) + "\"}"},
+
+        // Deeply nested structure
+        {"{\"l1\":{\"l2\":{\"l3\":{\"l4\":{\"l5\":{\"value\":\"deep\"}}}}}}"},
+
+        // Real-world like Kafka message
+        {
+            "{\"topic\":\"events\",\"partition\":0,\"offset\":12345,\"timestamp\":1609459200000,"
+                + "\"key\":\"user123\",\"value\":{\"event_type\":\"purchase\","
+                + "\"items\":[{\"sku\":\"ABC123\",\"qty\":2,\"price\":29.99},"
+                + "{\"sku\":\"XYZ789\",\"qty\":1,\"price\":49.99}],"
+                + "\"total\":109.97,\"currency\":\"USD\"}}"
+        }
+    };
+  }
+
+  /**
+   * Test that bytesToMap produces identical results to bytesToJsonNode + jsonNodeToMap
+   * for all payload types
+   */
+  @Test(dataProvider = "jsonPayloads")
+  public void testBytesToMapEquivalence(String jsonString)
+      throws IOException {
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    // Old approach: bytesToJsonNode + jsonNodeToMap
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes, 0, jsonBytes.length);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+
+    // New approach: bytesToMap directly
+    Map<String, Object> newResult = JsonUtils.bytesToMap(jsonBytes, 0, jsonBytes.length);
+
+    // Verify they are equal
+    assertEquals(newResult, oldResult,
+        "bytesToMap should produce identical result to bytesToJsonNode + jsonNodeToMap for: " + jsonString);
+  }
+
+  /**
+   * Test bytesToMap with offset and length parameters (partial array reading)
+   */
+  @Test
+  public void testBytesToMapWithOffset()
+      throws IOException {
+    String prefix = "GARBAGE";
+    String jsonString = "{\"key\":\"value\",\"num\":42}";
+    String suffix = "MORE_GARBAGE";
+    String combined = prefix + jsonString + suffix;
+
+    byte[] fullBytes = combined.getBytes(StandardCharsets.UTF_8);
+    int offset = prefix.length();
+    int length = jsonString.length();
+
+    // Old approach
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(fullBytes, offset, length);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+
+    // New approach
+    Map<String, Object> newResult = JsonUtils.bytesToMap(fullBytes, offset, length);
+
+    assertEquals(newResult, oldResult);
+    assertEquals(newResult.get("key"), "value");
+    assertEquals(newResult.get("num"), 42);
+  }
+
+  /**
+   * Test bytesToMap with offset where offset + length would exceed array bounds.
+   * This test ensures we're passing length (not offset+length) to Jackson API.
+   */
+  @Test
+  public void testBytesToMapWithOffsetEdgeCase()
+      throws IOException {
+    // Create a case where offset + length > array.length would fail if we incorrectly
+    // passed offset+length as the third parameter to Jackson's readValue
+    String prefix = "XX";  // 2 bytes
+    String jsonString = "{\"a\":1}";  // 7 bytes
+    // Total: 9 bytes
+    // offset=2, length=7
+    // If buggy (passing offset+length=9), would try to read 9 bytes from position 2,
+    // but only 7 bytes available from that position
+
+    String combined = prefix + jsonString;  // No suffix - exactly at the boundary
+    byte[] fullBytes = combined.getBytes(StandardCharsets.UTF_8);
+    int offset = prefix.length();
+    int length = jsonString.length();
+
+    // Verify array bounds: offset + length should equal array length exactly
+    assertEquals(fullBytes.length, offset + length,
+        "Test setup: offset + length should equal array length");
+
+    // This would fail with the bug: "Invalid 'offset' and/or 'len' arguments"
+    Map<String, Object> result = JsonUtils.bytesToMap(fullBytes, offset, length);
+    assertEquals(result.get("a"), 1);
+
+    // Verify equivalence with old approach
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(fullBytes, offset, length);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test bytesToMap with various offset positions to ensure correct slicing.
+   */
+  @Test
+  public void testBytesToMapWithVariousOffsets()
+      throws IOException {
+    String json = "{\"x\":\"y\"}";
+    byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8);
+
+    // Test with offset=0 (should work like no offset)
+    Map<String, Object> result0 = JsonUtils.bytesToMap(jsonBytes, 0, jsonBytes.length);
+    assertEquals(result0.get("x"), "y");
+
+    // Test with padding on both sides at different positions
+    for (int prefixLen = 1; prefixLen <= 10; prefixLen++) {
+      String prefix = "P".repeat(prefixLen);
+      String suffix = "S".repeat(5);
+      String combined = prefix + json + suffix;
+      byte[] fullBytes = combined.getBytes(StandardCharsets.UTF_8);
+
+      Map<String, Object> result = JsonUtils.bytesToMap(fullBytes, prefixLen, json.length());
+      assertEquals(result.get("x"), "y",
+          "Failed with prefix length " + prefixLen);
+
+      // Verify equivalence
+      JsonNode node = JsonUtils.bytesToJsonNode(fullBytes, prefixLen, json.length());
+      assertEquals(result, JsonUtils.jsonNodeToMap(node));
+    }
+  }
+
+  /**
+   * Test bytesToMap without offset (full array)
+   */
+  @Test
+  public void testBytesToMapFullArray()
+      throws IOException {
+    String jsonString = "{\"name\":\"test\",\"values\":[1,2,3]}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    // Old approach using full array methods
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+
+    // New approach
+    Map<String, Object> newResult = JsonUtils.bytesToMap(jsonBytes);
+
+    assertEquals(newResult, oldResult);
+  }
+
+  /**
+   * Test that numeric types are preserved correctly
+   */
+  @Test
+  public void testBytesToMapNumericTypes()
+      throws IOException {
+    String jsonString = "{\"int\":42,\"long\":9223372036854775807,\"double\":3.14159,\"float\":1.5}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    // Verify the types and values
+    assertEquals(result.get("int"), 42);
+    assertEquals(result.get("long"), 9223372036854775807L);
+    assertEquals(result.get("double"), 3.14159);
+    assertEquals(result.get("float"), 1.5);
+
+    // Also verify equivalence with old approach
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test nested object access after parsing
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testBytesToMapNestedAccess()
+      throws IOException {
+    String jsonString = "{\"outer\":{\"inner\":{\"value\":\"deep\"},\"array\":[1,2,3]}}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+    Map<String, Object> outer = (Map<String, Object>) result.get("outer");
+    Map<String, Object> inner = (Map<String, Object>) outer.get("inner");
+    List<Object> array = (List<Object>) outer.get("array");
+
+    assertEquals(inner.get("value"), "deep");
+    assertEquals(array, Arrays.asList(1, 2, 3));
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test null handling in bytesToMap
+   */
+  @Test
+  public void testBytesToMapNullHandling()
+      throws IOException {
+    String jsonString = "{\"nullField\":null,\"nested\":{\"alsoNull\":null}}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    assertTrue(result.containsKey("nullField"));
+    assertNull(result.get("nullField"));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> nested = (Map<String, Object>) result.get("nested");
+    assertTrue(nested.containsKey("alsoNull"));
+    assertNull(nested.get("alsoNull"));
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test boolean handling
+   */
+  @Test
+  public void testBytesToMapBooleanHandling()
+      throws IOException {
+    String jsonString = "{\"trueVal\":true,\"falseVal\":false}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    assertEquals(result.get("trueVal"), true);
+    assertEquals(result.get("falseVal"), false);
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test empty object and array
+   */
+  @Test
+  public void testBytesToMapEmptyStructures()
+      throws IOException {
+    String jsonString = "{\"emptyObj\":{},\"emptyArr\":[]}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> emptyObj = (Map<String, Object>) result.get("emptyObj");
+    assertTrue(emptyObj.isEmpty());
+
+    @SuppressWarnings("unchecked")
+    List<Object> emptyArr = (List<Object>) result.get("emptyArr");
+    assertTrue(emptyArr.isEmpty());
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test that the method correctly handles UTF-8 encoded bytes
+   */
+  @Test
+  public void testBytesToMapUtf8Encoding()
+      throws IOException {
+    // Test various UTF-8 characters
+    String jsonString = "{\"chinese\":\"中文\",\"japanese\":\"日本語\",\"korean\":\"한국어\","
+        + "\"emoji\":\"🎉🎊🎁\",\"mixed\":\"Hello世界\"}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    assertEquals(result.get("chinese"), "中文");
+    assertEquals(result.get("japanese"), "日本語");
+    assertEquals(result.get("korean"), "한국어");
+    assertEquals(result.get("emoji"), "🎉🎊🎁");
+    assertEquals(result.get("mixed"), "Hello世界");
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test escape sequences in strings
+   */
+  @Test
+  public void testBytesToMapEscapeSequences()
+      throws IOException {
+    String jsonString = "{\"quotes\":\"\\\"quoted\\\"\",\"backslash\":\"a\\\\b\","
+        + "\"newline\":\"line1\\nline2\",\"tab\":\"col1\\tcol2\","
+        + "\"unicode\":\"\\u0048\\u0065\\u006C\\u006C\\u006F\"}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    assertEquals(result.get("quotes"), "\"quoted\"");
+    assertEquals(result.get("backslash"), "a\\b");
+    assertEquals(result.get("newline"), "line1\nline2");
+    assertEquals(result.get("tab"), "col1\tcol2");
+    assertEquals(result.get("unicode"), "Hello");
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test mixed type arrays
+   */
+  @Test
+  public void testBytesToMapMixedArrays()
+      throws IOException {
+    String jsonString = "{\"mixed\":[1,\"two\",3.0,true,null,{\"nested\":\"obj\"},[1,2]]}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    @SuppressWarnings("unchecked")
+    List<Object> mixed = (List<Object>) result.get("mixed");
+    assertEquals(mixed.size(), 7);
+    assertEquals(mixed.get(0), 1);
+    assertEquals(mixed.get(1), "two");
+    assertEquals(mixed.get(2), 3.0);
+    assertEquals(mixed.get(3), true);
+    assertNull(mixed.get(4));
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
+  }
+
+  /**
+   * Test error handling - malformed JSON should throw IOException
+   */
+  @Test(expectedExceptions = IOException.class)
+  public void testBytesToMapMalformedJson()
+      throws IOException {
+    String malformedJson = "{\"key\":value}"; // missing quotes around value
+    byte[] jsonBytes = malformedJson.getBytes(StandardCharsets.UTF_8);
+    JsonUtils.bytesToMap(jsonBytes);
+  }
+
+  /**
+   * Test error handling - incomplete JSON
+   */
+  @Test(expectedExceptions = IOException.class)
+  public void testBytesToMapIncompleteJson()
+      throws IOException {
+    String incompleteJson = "{\"key\":\"value\""; // missing closing brace
+    byte[] jsonBytes = incompleteJson.getBytes(StandardCharsets.UTF_8);
+    JsonUtils.bytesToMap(jsonBytes);
+  }
+
+  /**
+   * Stress test with a large number of fields
+   */
+  @Test
+  public void testBytesToMapManyFields()
+      throws IOException {
+    StringBuilder sb = new StringBuilder("{");
+    for (int i = 0; i < 100; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append("\"field").append(i).append("\":").append(i);
+    }
+    sb.append("}");
+    String jsonString = sb.toString();
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    // Old approach
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+
+    // New approach
+    Map<String, Object> newResult = JsonUtils.bytesToMap(jsonBytes);
+
+    assertEquals(newResult, oldResult);
+    assertEquals(newResult.size(), 100);
+
+    for (int i = 0; i < 100; i++) {
+      assertEquals(newResult.get("field" + i), i);
+    }
+  }
+
+  /**
+   * Test with a deeply nested array structure
+   */
+  @Test
+  public void testBytesToMapDeeplyNestedArrays()
+      throws IOException {
+    String jsonString = "{\"data\":[[[[[\"deep\"]]]]]}";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+
+    Map<String, Object> result = JsonUtils.bytesToMap(jsonBytes);
+
+    // Verify equivalence
+    JsonNode jsonNode = JsonUtils.bytesToJsonNode(jsonBytes);
+    Map<String, Object> oldResult = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(result, oldResult);
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilderTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils.builder;
+
+import org.apache.pinot.spi.utils.StringUtil;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ControllerRequestURLBuilderTest {
+
+  @Test
+  public void testForConsumerWatermarksGet() {
+    ControllerRequestURLBuilder builder = ControllerRequestURLBuilder.baseUrl("http://localhost:9000");
+    assertEquals(builder.forConsumerWatermarksGet("myTable"),
+        StringUtil.join("/", "http://localhost:9000", "tables", "myTable", "consumerWatermarks"));
+  }
+}

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
@@ -99,7 +99,7 @@ public class TimeSeriesQueryEnvironment {
       RequestContext requestContext, TimeSeriesLogicalPlanResult logicalPlan) {
     // Step-0: Add table type info to the logical plan.
     logicalPlan = new TimeSeriesLogicalPlanResult(TableScanVisitor.INSTANCE.addTableTypeInfoToPlan(
-      logicalPlan.getPlanNode()), logicalPlan.getTimeBuckets());
+      logicalPlan.getPlanNode(), requestContext), logicalPlan.getTimeBuckets());
     // Step-1: Assign segments to servers for each leaf node.
     TableScanVisitor.Context scanVisitorContext = TableScanVisitor.createContext(requestContext.getRequestId());
     TableScanVisitor.INSTANCE.assignSegmentsToPlan(logicalPlan.getPlanNode(), logicalPlan.getTimeBuckets(),

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
     <tyrus-standalone-client.version>2.2.1</tyrus-standalone-client.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <ipaddress.version>5.5.1</ipaddress.version>
-    <openhft.chronicle-bom.version>2.27ea96</openhft.chronicle-bom.version>
+    <openhft.chronicle-bom.version>2.27ea98</openhft.chronicle-bom.version>
     <jdom2.version>2.0.6.1</jdom2.version>
     <maven.version>3.9.12</maven.version>
     <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2872,7 +2872,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.9.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <google.cloud.libraries.version>26.73.0</google.cloud.libraries.version>
     <google.auto-service.version>1.1.1</google.auto-service.version>
     <google.re2j.version>1.8</google.re2j.version>
-    <google.errorprone.version>2.45.0</google.errorprone.version>
+    <google.errorprone.version>2.46.0</google.errorprone.version>
     <google.j2objc.version>3.1</google.j2objc.version>
     <google.jsr305.version>3.0.2</google.jsr305.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.5</aws.sdk.version>
+    <aws.sdk.version>2.41.6</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2871,11 +2871,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.9.0</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <dependencies>
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2354,7 +2354,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.0</aws.sdk.version>
+    <aws.sdk.version>2.41.3</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
     <ivy.version>2.5.3</ivy.version>
     <c3p0.version>0.11.2</c3p0.version>
     <mchange-commons-java.version>0.3.2</mchange-commons-java.version>
-    <checker-qual.version>3.52.1</checker-qual.version>
+    <checker-qual.version>3.53.0</checker-qual.version>
     <groovy-all.version>2.4.21</groovy-all.version>
     <xml-apis.version>2.0.2</xml-apis.version>
     <roaring-bitmap.version>1.3.0</roaring-bitmap.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <arrow.version>18.3.0</arrow.version>
     <avro.version>1.12.1</avro.version>
     <parquet.version>1.16.0</parquet.version>
-    <orc.version>1.9.7</orc.version>
+    <orc.version>1.9.8</orc.version>
     <hive.version>2.8.1</hive.version>
     <helix.version>1.3.2</helix.version>
     <zkclient.version>0.11</zkclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
     <tyrus-standalone-client.version>2.2.1</tyrus-standalone-client.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <ipaddress.version>5.5.1</ipaddress.version>
-    <openhft.chronicle-bom.version>2.27ea98</openhft.chronicle-bom.version>
+    <openhft.chronicle-bom.version>2.27ea99</openhft.chronicle-bom.version>
     <jdom2.version>2.0.6.1</jdom2.version>
     <maven.version>3.9.12</maven.version>
     <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
     <tyrus-standalone-client.version>2.2.1</tyrus-standalone-client.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>
     <ipaddress.version>5.5.1</ipaddress.version>
-    <openhft.chronicle-bom.version>2.27ea99</openhft.chronicle-bom.version>
+    <openhft.chronicle-bom.version>2.27ea100</openhft.chronicle-bom.version>
     <jdom2.version>2.0.6.1</jdom2.version>
     <maven.version>3.9.12</maven.version>
     <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.7</aws.sdk.version>
+    <aws.sdk.version>2.41.8</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -234,8 +234,8 @@
     <!-- HTTP Components Libraries -->
     <httpclient.version>4.5.14</httpclient.version>
     <httpcore.version>4.4.16</httpcore.version>
-    <httpclient5.version>5.5.1</httpclient5.version>
-    <httpcore5.version>5.3.6</httpcore5.version>
+    <httpclient5.version>5.6</httpclient5.version>
+    <httpcore5.version>5.4</httpcore5.version>
 
     <!-- Google Libraries -->
     <protobuf.version>3.25.8</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>36</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>org.apache.pinot</groupId>
@@ -965,7 +965,7 @@
         </exclusions>
       </dependency>
 
-     <!-- JMX exporter-->
+      <!-- JMX exporter-->
       <dependency>
         <groupId>io.prometheus.jmx</groupId>
         <artifactId>jmx_prometheus_javaagent</artifactId>
@@ -2180,7 +2180,7 @@
               <importOrder>
                 <order>,\#</order>
               </importOrder>
-              <removeUnusedImports />
+              <removeUnusedImports/>
             </java>
           </configuration>
         </plugin>
@@ -2319,7 +2319,7 @@
               <phase>validate</phase>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                   <bannedDependencies>
                     <excludes>
                       <!-- Use org.slf4j:jcl-over-slf4j -->
@@ -2871,6 +2871,11 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <dependencies>
           <dependency>
@@ -2893,8 +2898,8 @@
           <transformers>
             <!-- See https://logging.apache.org/log4j/transform for details -->
             <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>${mainClass}</mainClass>
               <manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
     <jline.version>3.30.6</jline.version>
     <wildfly.version>2.0.1</wildfly.version>
     <jettison.version>1.5.4</jettison.version>
-    <nimbus-jose-jwt.version>10.6</nimbus-jose-jwt.version>
+    <nimbus-jose-jwt.version>10.7</nimbus-jose-jwt.version>
     <dnsjava.version>3.6.3</dnsjava.version>
     <eclipse.jetty.version>9.4.58.v20250814</eclipse.jetty.version>
     <woodstox.version>7.1.1</woodstox.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2429,7 +2429,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>javacc-maven-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.0</version>
           <dependencies>
             <dependency>
               <groupId>net.java.dev.javacc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <jsonsmart.version>2.6.0</jsonsmart.version>
     <quartz.version>2.5.2</quartz.version>
     <calcite.version>1.40.0</calcite.version>
-    <immutables.version>2.12.0</immutables.version>
+    <immutables.version>2.12.1</immutables.version>
     <lucene.version>9.12.0</lucene.version>
     <reflections.version>0.10.2</reflections.version>
     <dynatrace.hash4j.version>0.26.0</dynatrace.hash4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.8</aws.sdk.version>
+    <aws.sdk.version>2.41.9</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.4</aws.sdk.version>
+    <aws.sdk.version>2.41.5</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.6</aws.sdk.version>
+    <aws.sdk.version>2.41.7</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.3</aws.sdk.version>
+    <aws.sdk.version>2.41.4</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
     <!-- Google Libraries -->
     <protobuf.version>3.25.8</protobuf.version>
     <grpc.version>1.78.0</grpc.version>
-    <google.cloud.libraries.version>26.73.0</google.cloud.libraries.version>
+    <google.cloud.libraries.version>26.74.0</google.cloud.libraries.version>
     <google.auto-service.version>1.1.1</google.auto-service.version>
     <google.re2j.version>1.8</google.re2j.version>
     <google.errorprone.version>2.46.0</google.errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>36</version>
+    <version>37</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2359,7 +2359,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
     <maven.version>3.9.12</maven.version>
     <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>
     <plexus-utils.version>3.6.0</plexus-utils.version>
-    <animal-sniffer-annotations.version>1.26</animal-sniffer-annotations.version>
+    <animal-sniffer-annotations.version>1.27</animal-sniffer-annotations.version>
 
     <!-- Test Libraries -->
     <testng.version>7.11.0</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <woodstox.version>7.1.1</woodstox.version>
     <curator.version>5.9.0</curator.version>
     <javassist.version>3.30.2-GA</javassist.version>
-    <bouncycastle.version>1.78.1</bouncycastle.version>
+    <bouncycastle.version>1.83</bouncycastle.version>
     <aircompressor.version>0.27</aircompressor.version>
     <jna.version>5.18.1</jna.version>
     <jnr-ffi.version>2.2.18</jnr-ffi.version>
@@ -1931,11 +1931,6 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcutil-jdk18on</artifactId>
-        <version>${bouncycastle.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-ext-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
       <!-- Used by ORC, Parquet and Pulsar -->

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 
     <arrow.version>18.3.0</arrow.version>
     <avro.version>1.12.1</avro.version>
-    <parquet.version>1.16.0</parquet.version>
+    <parquet.version>1.17.0</parquet.version>
     <orc.version>1.9.8</orc.version>
     <hive.version>2.8.1</hive.version>
     <helix.version>1.3.2</helix.version>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <enforcer-api.version>3.6.2</enforcer-api.version>
 
     <spark2.version>2.4.8</spark2.version>
-    <spark3.version>3.5.7</spark3.version>
+    <spark3.version>3.5.8</spark3.version>
     <kafka2.version>2.8.2</kafka2.version>
     <kafka3.version>3.9.1</kafka3.version>
     <confluent.version>7.7.0</confluent.version>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
     <wildfly.version>2.0.1</wildfly.version>
     <jettison.version>1.5.4</jettison.version>
     <nimbus-jose-jwt.version>10.7</nimbus-jose-jwt.version>
-    <dnsjava.version>3.6.3</dnsjava.version>
+    <dnsjava.version>3.6.4</dnsjava.version>
     <eclipse.jetty.version>9.4.58.v20250814</eclipse.jetty.version>
     <woodstox.version>7.1.1</woodstox.version>
     <curator.version>5.9.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.10</aws.sdk.version>
+    <aws.sdk.version>2.41.11</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <hive.version>2.8.1</hive.version>
     <helix.version>1.3.2</helix.version>
     <zkclient.version>0.11</zkclient.version>
-    <jackson.version>2.20.1</jackson.version>
+    <jackson.version>2.21.0</jackson.version>
     <zookeeper.version>3.9.4</zookeeper.version>
     <async-http-client.version>3.0.6</async-http-client.version>
     <jersey.version>2.47</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>
     <stax2-api.version>4.2.2</stax2-api.version>
-    <aws.sdk.version>2.41.9</aws.sdk.version>
+    <aws.sdk.version>2.41.10</aws.sdk.version>
     <azure.sdk.version>1.3.3</azure.sdk.version>
     <azure.msal4j.version>1.23.1</azure.msal4j.version>
     <joda-time.version>2.14.0</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>35</version>
+    <version>36</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
- Create an async controller zk jobs to deeply backfill historical segments prior to the inducted consumer watermarks. The deep copy means replicating segments to a standalone remote storage path.
- Introduced TableReplicator to fetch segment ZK metadata from the source, register a controller job, and submit 4 worker tasks (can be fine tuned in the future) that call a SegmentCopier for each segment; errors immediately trigger job updates and completed segments are batched for ZK updates.  
- Added ZkBasedTableReplicationObserver and TableReplicationProgressStats to keep in-memory progress (remaining count and failed segment list) and persist job metadata to ZK (including a SEGMENTS_TO_BE_COPIED field) every 100 completions or immediately on error.  
- Implemented SegmentCopier interface with RealtimeSegmentCopier (deep-copy mode) that copies segments between the same PinotFS scheme and uploads the segment URI to the destination controller; if a segment lacks a deep-store download URL the code logs the problem and records failures.